### PR TITLE
Verify_flash_params

### DIFF
--- a/include/canhardware.h
+++ b/include/canhardware.h
@@ -1,0 +1,87 @@
+/*
+ * This file is part of the tumanako_vc project.
+ *
+ * Copyright (C) 2018 Johannes Huebner <dev@johanneshuebner.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef CANHARDWARE_H
+#define CANHARDWARE_H
+
+#include <stdint.h>
+
+#ifndef MAX_USER_MESSAGES
+#define MAX_USER_MESSAGES 30
+#endif
+
+#ifndef MAX_RECV_CALLBACKS
+#define MAX_RECV_CALLBACKS 2
+#endif
+
+class CanCallback
+{
+public:
+   virtual bool HandleRx(uint32_t canId, uint32_t data[2]) = 0;
+   virtual void HandleClear() = 0;
+};
+
+class FunctionPointerCallback: public CanCallback
+{
+public:
+   FunctionPointerCallback(bool (*r)(uint32_t, uint32_t*), void (*c)()) : recv(r), clear(c) { };
+   bool HandleRx(uint32_t canId, uint32_t data[2]) { return recv(canId, data); }
+   void HandleClear() { clear(); }
+
+private:
+   bool (*recv)(uint32_t, uint32_t*);
+   void (*clear)();
+};
+
+class CanHardware
+{
+   public:
+      enum baudrates
+      {
+         Baud125, Baud250, Baud500, Baud800, Baud1000, BaudLast
+      };
+
+      CanHardware();
+      virtual void SetBaudrate(enum baudrates baudrate) = 0;
+      void Send(uint32_t canId, uint32_t data[2]) { Send(canId, data, 8); }
+      void Send(uint32_t canId, uint8_t data[8], uint8_t len) { Send(canId, (uint32_t*)data, len); }
+      virtual void Send(uint32_t canId, uint32_t data[2], uint8_t len) = 0;
+      void HandleRx(uint32_t canId, uint32_t data[2]);
+      bool AddReceiveCallback(CanCallback* cb);
+      bool RegisterUserMessage(uint32_t canId);
+      void ClearUserMessages();
+      /** \brief Get RTC time when last message was received
+       *
+       * \return uint32_t RTC time
+       *
+       */
+      uint32_t GetLastRxTimestamp() { return lastRxTimestamp; }
+
+   protected:
+      uint16_t userIds[MAX_USER_MESSAGES];
+      int nextUserMessageIndex;
+      uint32_t lastRxTimestamp;
+
+   private:
+      int nextCallbackIndex;
+      CanCallback* recvCallback[MAX_RECV_CALLBACKS];
+
+      virtual void ConfigureFilters() = 0;
+};
+
+#endif // CANHARDWARE_H

--- a/include/canmap.h
+++ b/include/canmap.h
@@ -1,0 +1,103 @@
+/*
+ * This file is part of the tumanako_vc project.
+ *
+ * Copyright (C) 2018 Johannes Huebner <dev@johanneshuebner.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef CANMAP_H
+#define CANMAP_H
+#include "params.h"
+#include "canhardware.h"
+
+#define CAN_ERR_INVALID_ID -1
+#define CAN_ERR_INVALID_OFS -2
+#define CAN_ERR_INVALID_LEN -3
+#define CAN_ERR_MAXMESSAGES -4
+#define CAN_ERR_MAXITEMS -5
+
+#ifndef MAX_ITEMS
+#define MAX_ITEMS 50
+#endif
+
+#ifndef MAX_MESSAGES
+#define MAX_MESSAGES 10
+#endif
+
+class CanMap: CanCallback
+{
+   public:
+      /** Default constructor */
+      CanMap(CanHardware* hw);
+      void HandleClear();
+      bool HandleRx(uint32_t canId, uint32_t data[2]);
+      void Clear();
+      void SendAll();
+      void SDOWrite(uint8_t remoteNodeId, uint16_t index, uint8_t subIndex, uint32_t data);
+      void SetNodeId(uint8_t id) { nodeId = id; }
+      int AddSend(Param::PARAM_NUM param, uint32_t canId, uint8_t offsetBits, uint8_t length, float gain);
+      int AddRecv(Param::PARAM_NUM param, uint32_t canId, uint8_t offsetBits, uint8_t length, float gain);
+      int AddSend(Param::PARAM_NUM param, uint32_t canId, uint8_t offsetBits, uint8_t length, float gain, int8_t offset);
+      int AddRecv(Param::PARAM_NUM param, uint32_t canId, uint8_t offsetBits, uint8_t length, float gain, int8_t offset);
+      int Remove(Param::PARAM_NUM param);
+      void Save();
+      bool FindMap(Param::PARAM_NUM param, uint32_t& canId, uint8_t& offset, uint8_t& length, float& gain, bool& rx);
+      void IterateCanMap(void (*callback)(Param::PARAM_NUM, uint32_t, uint8_t, uint8_t, float, bool));
+
+   protected:
+
+   private:
+      static volatile bool isSaving;
+
+      struct CANPOS
+      {
+         float gain;
+         uint16_t mapParam;
+         int8_t offset;
+         uint8_t offsetBits;
+         uint8_t numBits;
+         uint8_t next;
+      };
+
+      struct CANIDMAP
+      {
+         #ifdef CAN_EXT
+         uint32_t canId;
+         #else
+         uint16_t canId;
+         #endif // CAN_EXT
+         uint8_t first;
+      };
+
+      CanHardware* canHardware;
+      CANIDMAP canSendMap[MAX_MESSAGES];
+      CANIDMAP canRecvMap[MAX_MESSAGES];
+      CANPOS canPosMap[MAX_ITEMS + 1]; //Last item is a "tail"
+      uint32_t lastRxTimestamp;
+      uint8_t nodeId;
+
+      void ProcessSDO(uint32_t data[2]);
+      void ClearMap(CANIDMAP *canMap);
+      int RemoveFromMap(CANIDMAP *canMap, Param::PARAM_NUM param);
+      int Add(CANIDMAP *canMap, Param::PARAM_NUM param, uint32_t canId, uint8_t offsetBits, uint8_t length, float gain, int8_t offset);
+      uint32_t SaveToFlash(uint32_t baseAddress, uint32_t* data, int len);
+      int LoadFromFlash();
+      CANIDMAP *FindById(CANIDMAP *canMap, uint32_t canId);
+      int CopyIdMapExcept(CANIDMAP *source, CANIDMAP *dest, Param::PARAM_NUM param);
+      void ReplaceParamEnumByUid(CANIDMAP *canMap);
+      void ReplaceParamUidByEnum(CANIDMAP *canMap);
+      uint32_t GetFlashAddress();
+};
+
+#endif // CANMAP_H

--- a/include/my_math.h
+++ b/include/my_math.h
@@ -20,6 +20,7 @@
 #define MY_MATH_H_INCLUDED
 
 #define ABS(a)   ((a) < 0?(-(a)) : (a))
+#define SIGN(a)  ((a) < 0? -1 : 1)
 #define MIN(a,b) ((a) < (b)?(a):(b))
 #define MAX(a,b) ((a) > (b)?(a):(b))
 #define RAMPUP(current, target, rate) ((target < current || (current + rate) > target) ? target : current + rate)

--- a/include/stm32_can.h
+++ b/include/stm32_can.h
@@ -19,90 +19,23 @@
  */
 #ifndef STM32_CAN_H_INCLUDED
 #define STM32_CAN_H_INCLUDED
-#include "params.h"
-
-#define CAN_ERR_INVALID_ID -1
-#define CAN_ERR_INVALID_OFS -2
-#define CAN_ERR_INVALID_LEN -3
-#define CAN_ERR_MAXMESSAGES -4
-#define CAN_ERR_MAXITEMS -5
-
-#ifndef MAX_ITEMS
-#define MAX_ITEMS 70
-#endif // MAX_ITEMS_PER_MESSAGE
-
-#ifndef MAX_MESSAGES
-#define MAX_MESSAGES 10
-#endif // MAX_MESSAGES
+#include "canhardware.h"
 
 #ifndef SENDBUFFER_LEN
 #define SENDBUFFER_LEN 20
 #endif // SENDBUFFER_LEN
 
-#ifndef MAX_USER_MESSAGES
-#define MAX_USER_MESSAGES 10
-#endif // MAX_USER_MESSAGES
-
-
-class CANIDMAP;
-class SENDBUFFER;
-
-class Can
+class Stm32Can: public CanHardware
 {
 public:
-   enum baudrates
-   {
-      Baud125, Baud250, Baud500, Baud800, Baud1000, BaudLast
-   };
-
-   Can(uint32_t baseAddr, enum baudrates baudrate, bool remap = false);
-   void Clear(void);
+   Stm32Can(uint32_t baseAddr, enum baudrates baudrate, bool remap = false);
    void SetBaudrate(enum baudrates baudrate);
-   void Send(uint32_t canId, uint32_t data[2]) { Send(canId, data, 8); }
-   void Send(uint32_t canId, uint8_t data[8], uint8_t len) { Send(canId, (uint32_t*)data, len); }
    void Send(uint32_t canId, uint32_t data[2], uint8_t len);
-   void SendAll();
-   void SDOWrite(uint8_t remoteNodeId, uint16_t index, uint8_t subIndex, uint32_t data);
-   void Save();
-   void SetReceiveCallback(void (*recv)(uint32_t, uint32_t*));
-   bool RegisterUserMessage(uint32_t canId);
-   void ClearUserMessages();
-   uint32_t GetLastRxTimestamp();
-   int AddSend(Param::PARAM_NUM param, uint32_t canId, uint8_t offsetBits, uint8_t length, float gain);
-   int AddRecv(Param::PARAM_NUM param, uint32_t canId, uint8_t offsetBits, uint8_t length, float gain);
-   int AddSend(Param::PARAM_NUM param, uint32_t canId, uint8_t offsetBits, uint8_t length, float gain, int8_t offset);
-   int AddRecv(Param::PARAM_NUM param, uint32_t canId, uint8_t offsetBits, uint8_t length, float gain, int8_t offset);
-   int Remove(Param::PARAM_NUM param);
-   bool FindMap(Param::PARAM_NUM param, uint32_t& canId, uint8_t& offset, uint8_t& length, float& gain, bool& rx);
-   void IterateCanMap(void (*callback)(Param::PARAM_NUM, uint32_t, uint8_t, uint8_t, float, bool));
-   void HandleRx(int fifo);
    void HandleTx();
-   void SetNodeId(uint8_t id) { nodeId = id; }
-   static Can* GetInterface(int index);
+   void HandleMessage(int fifo);
+   static Stm32Can* GetInterface(int index);
 
 private:
-   static volatile bool isSaving;
-
-   struct CANPOS
-   {
-      float gain;
-      uint16_t mapParam;
-      int8_t offset;
-      uint8_t offsetBits;
-      uint8_t numBits;
-      uint8_t next;
-   };
-
-   struct CANIDMAP
-   {
-      #ifdef CAN_EXT
-      uint32_t canId;
-      #else
-      uint16_t canId;
-      #endif // CAN_EXT
-      uint8_t first;
-   };
-
    struct SENDBUFFER
    {
       uint32_t id;
@@ -110,34 +43,16 @@ private:
       uint32_t data[2];
    };
 
-   CANIDMAP canSendMap[MAX_MESSAGES];
-   CANIDMAP canRecvMap[MAX_MESSAGES];
-   CANPOS canPosMap[MAX_ITEMS + 1]; //Last item is a "tail"
-   uint32_t lastRxTimestamp;
    SENDBUFFER sendBuffer[SENDBUFFER_LEN];
    int sendCnt;
-   void (*recvCallback)(uint32_t, uint32_t*);
-   uint16_t userIds[MAX_USER_MESSAGES];
-   int nextUserMessageIndex;
    uint32_t canDev;
-   uint8_t nodeId;
 
-   void ProcessSDO(uint32_t data[2]);
-   void ClearMap(CANIDMAP *canMap);
-   int RemoveFromMap(CANIDMAP *canMap, Param::PARAM_NUM param);
-   int Add(CANIDMAP *canMap, Param::PARAM_NUM param, uint32_t canId, uint8_t offsetBits, uint8_t length, float gain, int8_t offset);
-   uint32_t SaveToFlash(uint32_t baseAddress, uint32_t* data, int len);
-   int LoadFromFlash();
-   CANIDMAP *FindById(CANIDMAP *canMap, uint32_t canId);
-   int CopyIdMapExcept(CANIDMAP *source, CANIDMAP *dest, Param::PARAM_NUM param);
-   void ReplaceParamEnumByUid(CANIDMAP *canMap);
-   void ReplaceParamUidByEnum(CANIDMAP *canMap);
    void ConfigureFilters();
    void SetFilterBank(int& idIndex, int& filterId, uint16_t* idList);
    void SetFilterBank29(int& idIndex, int& filterId, uint32_t* idList);
    uint32_t GetFlashAddress();
 
-   static Can* interfaces[];
+   static Stm32Can* interfaces[];
 };
 
 

--- a/include/terminalcommands.h
+++ b/include/terminalcommands.h
@@ -18,7 +18,7 @@
  */
 #ifndef TERMINALCOMMANDS_H
 #define TERMINALCOMMANDS_H
-
+#include "canmap.h"
 
 class TerminalCommands
 {
@@ -32,11 +32,13 @@ class TerminalCommands
       static void SaveParameters(Terminal* term, char *arg);
       static void LoadParameters(Terminal* term, char *arg);
       static void Reset(Terminal* term, char *arg);
+      static void SetCanMap(CanMap* m) { canMap = m; }
 
    protected:
 
    private:
       static void PrintCanMap(Param::PARAM_NUM param, uint32_t canid, uint8_t offset, uint8_t length, float gain, bool rx);
+      static CanMap* canMap;
 };
 
 #endif // TERMINALCOMMANDS_H

--- a/src/canhardware.cpp
+++ b/src/canhardware.cpp
@@ -1,0 +1,99 @@
+/*
+ * This file is part of the stm32-... project.
+ *
+ * Copyright (C) 2021 Johannes Huebner <dev@johanneshuebner.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "canhardware.h"
+
+class NullCallback: public CanCallback
+{
+public:
+   bool HandleRx(uint32_t, uint32_t*) { return false; }
+   void HandleClear() { }
+};
+
+
+static NullCallback nullCallback;
+
+CanHardware::CanHardware()
+   : nextUserMessageIndex(0), nextCallbackIndex(0)
+{
+   for (int i = 0; i < MAX_RECV_CALLBACKS; i++)
+   {
+      recvCallback[i] = &nullCallback;
+   }
+}
+
+/** \brief Add interface to be called for user handled CAN messages
+ *
+ * \param recv CanCallback interface
+ */
+bool CanHardware::AddReceiveCallback(CanCallback* recv)
+{
+   if (nextCallbackIndex < MAX_RECV_CALLBACKS)
+   {
+      recvCallback[nextCallbackIndex] = recv;
+      nextCallbackIndex++;
+      return true;
+   }
+   return false;
+}
+
+/** \brief Add CAN Id to user message list
+ * \post Receive callback will be called when a message with this Id id received
+ * \param canId CAN identifier of message to be user handled
+ * \return true: success, false: already 10 messages registered
+ *
+ */
+bool CanHardware::RegisterUserMessage(uint32_t canId)
+{
+   if (nextUserMessageIndex < MAX_USER_MESSAGES)
+   {
+      for (int i = 0; i < nextUserMessageIndex; i++)
+      {
+         if (canId == userIds[i]) //already exists
+            return false; //do not add again
+      }
+
+      userIds[nextUserMessageIndex] = canId;
+      nextUserMessageIndex++;
+      ConfigureFilters();
+      return true;
+   }
+   return false;
+}
+
+/** \brief Remove all CAN Id from user message list
+ */
+void CanHardware::ClearUserMessages()
+{
+   nextUserMessageIndex = 0;
+   ConfigureFilters();
+
+   for (int i = 0; i < nextCallbackIndex; i++)
+   {
+      recvCallback[i]->HandleClear();
+   }
+}
+
+void CanHardware::HandleRx(uint32_t canId, uint32_t data[2])
+{
+   for (int i = 0; i < nextCallbackIndex; i++)
+   {
+      if (recvCallback[i]->HandleRx(canId, data))
+         break;
+   }
+}

--- a/src/canmap.cpp
+++ b/src/canmap.cpp
@@ -1,0 +1,589 @@
+/*
+ * This file is part of the stm32-... project.
+ *
+ * Copyright (C) 2021 Johannes Huebner <dev@johanneshuebner.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "canmap.h"
+#include "hwdefs.h"
+#include "my_string.h"
+#include <libopencm3/stm32/flash.h>
+#include <libopencm3/stm32/crc.h>
+#include <libopencm3/stm32/desig.h>
+
+#define SDO_WRITE             0x40
+#define SDO_READ              0x22
+#define SDO_ABORT             0x80
+#define SDO_WRITE_REPLY       0x23
+#define SDO_READ_REPLY        0x43
+#define SDO_ERR_INVIDX        0x06020000
+#define SDO_ERR_RANGE         0x06090030
+#define SENDMAP_ADDRESS(b)    b
+#define RECVMAP_ADDRESS(b)    (b + sizeof(canSendMap))
+#define POSMAP_ADDRESS(b)     (b + sizeof(canSendMap) + sizeof(canRecvMap))
+#define CRC_ADDRESS(b)        (b + sizeof(canSendMap) + sizeof(canRecvMap) + sizeof(canPosMap))
+#define SENDMAP_WORDS         (sizeof(canSendMap) / (sizeof(uint32_t)))
+#define RECVMAP_WORDS         (sizeof(canRecvMap) / (sizeof(uint32_t)))
+#define POSMAP_WORDS          ((sizeof(CANPOS) * MAX_ITEMS) / (sizeof(uint32_t)))
+#define ITEM_UNSET            0xff
+#define forEachCanMap(c,m) for (CANIDMAP *c = m; (c - m) < MAX_MESSAGES && c->first != MAX_ITEMS; c++)
+#define forEachPosMap(c,m) for (CANPOS *c = &canPosMap[m->first]; c->next != ITEM_UNSET; c = &canPosMap[c->next])
+
+#ifdef CAN_EXT
+#define IDMAPSIZE 8
+#else
+#define IDMAPSIZE 4
+#endif // CAN_EXT
+#if (MAX_ITEMS * 12 + 2 * MAX_MESSAGES * IDMAPSIZE + 4) > FLASH_PAGE_SIZE
+#error CANMAP will not fit in one flash page
+#endif
+
+struct CAN_SDO
+{
+   uint8_t cmd;
+   uint16_t index;
+   uint8_t subIndex;
+   uint32_t data;
+} __attribute__((packed));
+
+volatile bool CanMap::isSaving = false;
+
+CanMap::CanMap(CanHardware* hw)
+ : canHardware(hw), nodeId(1)
+{
+   canHardware->AddReceiveCallback(this);
+
+   ClearMap(canSendMap);
+   ClearMap(canRecvMap);
+   LoadFromFlash();
+   HandleClear();
+}
+
+//Somebody (perhaps us) has cleared all user messages. Register them again
+void CanMap::HandleClear()
+{
+   forEachCanMap(curMap, canRecvMap)
+   {
+      canHardware->RegisterUserMessage(curMap->canId);
+   }
+}
+
+bool CanMap::HandleRx(uint32_t canId, uint32_t data[2])
+{
+   if (canId == (0x600U + nodeId)) //SDO request
+   {
+      ProcessSDO(data);
+      return true;
+   }
+   else
+   {
+      if (isSaving) return false; //Only handle mapped messages when not currently saving to flash
+
+      CANIDMAP *recvMap = FindById(canRecvMap, canId);
+
+      if (0 != recvMap)
+      {
+         forEachPosMap(curPos, recvMap)
+         {
+            float val;
+
+            if (curPos->offsetBits > 31)
+            {
+               val = (data[1] >> (curPos->offsetBits - 32)) & ((1 << curPos->numBits) - 1);
+            }
+            else
+            {
+               val = (data[0] >> curPos->offsetBits) & ((1 << curPos->numBits) - 1);
+            }
+            val += curPos->offset;
+            val *= curPos->gain;
+
+            if (Param::IsParam((Param::PARAM_NUM)curPos->mapParam))
+               Param::Set((Param::PARAM_NUM)curPos->mapParam, FP_FROMFLT(val));
+            else
+               Param::SetFloat((Param::PARAM_NUM)curPos->mapParam, val);
+         }
+         return true;
+      }
+   }
+   return false;
+}
+
+/** \brief Clear all defined messages
+ */
+void CanMap::Clear()
+{
+   ClearMap(canSendMap);
+   ClearMap(canRecvMap);
+   canHardware->ClearUserMessages();
+}
+
+/** \brief Send all defined messages
+ */
+void CanMap::SendAll()
+{
+   forEachCanMap(curMap, canSendMap)
+   {
+      uint32_t data[2] = { 0 }; //Had an issue with uint64_t, otherwise would have used that
+
+      forEachPosMap(curPos, curMap)
+      {
+         if (isSaving) return; //Only send mapped messages when not currently saving to flash
+
+         float val = Param::GetFloat((Param::PARAM_NUM)curPos->mapParam);
+
+         val *= curPos->gain;
+         val += curPos->offset;
+         int ival = val;
+         ival &= ((1 << curPos->numBits) - 1);
+
+         if (curPos->offsetBits > 31)
+         {
+            data[1] |= ival << (curPos->offsetBits - 32);
+         }
+         else
+         {
+            data[0] |= ival << curPos->offsetBits;
+         }
+      }
+
+      canHardware->Send(curMap->canId, data);
+   }
+}
+
+void CanMap::SDOWrite(uint8_t remoteNodeId, uint16_t index, uint8_t subIndex, uint32_t data)
+{
+   uint32_t d[2];
+   CAN_SDO *sdo = (CAN_SDO*)d;
+
+   sdo->cmd = SDO_WRITE;
+   sdo->index = index;
+   sdo->subIndex = subIndex;
+   sdo->data = data;
+
+   canHardware->Send(0x600 + remoteNodeId, d);
+}
+
+/** \brief Add periodic CAN message
+ *
+ * \param param Parameter index of parameter to be sent
+ * \param canId CAN identifier of generated message
+ * \param offset bit offset within the 64 message bits
+ * \param length number of bits
+ * \param gain Fixed point gain to be multiplied before sending
+ * \return success: number of active messages
+ * Fault:
+ * - CAN_ERR_INVALID_ID ID was > 0x1fffffff
+ * - CAN_ERR_INVALID_OFS Offset > 63
+ * - CAN_ERR_INVALID_LEN Length > 32
+ * - CAN_ERR_MAXMESSAGES Already 10 send messages defined
+ * - CAN_ERR_MAXITEMS Already than MAX_ITEMS items total defined
+ */
+int CanMap::AddSend(Param::PARAM_NUM param, uint32_t canId, uint8_t offsetBits, uint8_t length, float gain, int8_t offset)
+{
+   return Add(canSendMap, param, canId, offsetBits, length, gain, offset);
+}
+
+int CanMap::AddSend(Param::PARAM_NUM param, uint32_t canId, uint8_t offsetBits, uint8_t length, float gain)
+{
+   return Add(canSendMap, param, canId, offsetBits, length, gain, 0);
+}
+
+/** \brief Map data from CAN bus to parameter
+ *
+ * \param param Parameter index of parameter to be received
+ * \param canId CAN identifier of consumed message
+ * \param offset bit offset within the 64 message bits
+ * \param length number of bits
+ * \param gain Fixed point gain to be multiplied after receiving
+ * \return success: number of active messages
+ * Fault:
+ * - CAN_ERR_INVALID_ID ID was > 0x1fffffff
+ * - CAN_ERR_INVALID_OFS Offset > 63
+ * - CAN_ERR_INVALID_LEN Length > 32
+ * - CAN_ERR_MAXMESSAGES Already 10 receive messages defined
+ * - CAN_ERR_MAXITEMS Already than MAX_ITEMS items total defined
+ */
+int CanMap::AddRecv(Param::PARAM_NUM param, uint32_t canId, uint8_t offsetBits, uint8_t length, float gain, int8_t offset)
+{
+   int res = Add(canRecvMap, param, canId, offsetBits, length, gain, offset);
+   canHardware->RegisterUserMessage(canId);
+   return res;
+}
+
+int CanMap::AddRecv(Param::PARAM_NUM param, uint32_t canId, uint8_t offsetBits, uint8_t length, float gain)
+{
+   return AddRecv(param, canId, offsetBits, length, gain, 0);
+}
+
+/** \brief Remove all occurences of given parameter from CAN map
+ *
+ * \param param Parameter index to be removed
+ * \return int number of removed items
+ *
+ */
+int CanMap::Remove(Param::PARAM_NUM param)
+{
+   int removed = RemoveFromMap(canSendMap, param);
+   removed += RemoveFromMap(canRecvMap, param);
+
+   return removed;
+}
+
+/** \brief Save CAN mapping to flash
+ */
+void CanMap::Save()
+{
+   uint32_t crc;
+   uint32_t check = 0xFFFFFFFF;
+   uint32_t baseAddress = GetFlashAddress();
+   uint32_t *checkAddress = (uint32_t*)baseAddress;
+
+   isSaving = true;
+
+   for (int i = 0; i < FLASH_PAGE_SIZE / 4; i++, checkAddress++)
+      check &= *checkAddress;
+
+   crc_reset();
+
+   flash_unlock();
+   flash_set_ws(2);
+
+   if (check != 0xFFFFFFFF) //Only erase when needed
+      flash_erase_page(baseAddress);
+
+   ReplaceParamEnumByUid(canSendMap);
+   ReplaceParamEnumByUid(canRecvMap);
+
+   SaveToFlash(SENDMAP_ADDRESS(baseAddress), (uint32_t *)canSendMap, SENDMAP_WORDS);
+   crc = SaveToFlash(RECVMAP_ADDRESS(baseAddress), (uint32_t *)canRecvMap, RECVMAP_WORDS);
+   crc = SaveToFlash(POSMAP_ADDRESS(baseAddress), (uint32_t *)canPosMap, POSMAP_WORDS);
+   SaveToFlash(CRC_ADDRESS(baseAddress), &crc, 1);
+   flash_lock();
+
+   ReplaceParamUidByEnum(canSendMap);
+   ReplaceParamUidByEnum(canRecvMap);
+
+   isSaving = false;
+}
+
+
+/** \brief Find first occurence of parameter in CAN map and output its mapping info
+ *
+ * Memory layout: SendMap, RecvMap, PosMap, CRC
+ * Send/Recv maps point to items in PosMap. PosMap may point to next item
+ *
+ * \param[in] param Index of parameter to be looked up
+ * \param[out] canId CAN identifier that the parameter is mapped to
+ * \param[out] offset bit offset that the parameter is mapped to
+ * \param[out] length number of bits that the parameter is mapped to
+ * \param[out] gain Parameter gain
+ * \param[out] rx true: Parameter is received via CAN, false: sent via CAN
+ * \return true: parameter is mapped, false: not mapped
+ */
+bool CanMap::FindMap(Param::PARAM_NUM param, uint32_t& canId, uint8_t& offset, uint8_t& length, float& gain, bool& rx)
+{
+   rx = false;
+   bool done = false;
+
+   for (CANIDMAP *map = canSendMap; !done; map = canRecvMap)
+   {
+      forEachCanMap(curMap, map)
+      {
+         forEachPosMap(curPos, curMap)
+         {
+            if (curPos->mapParam == param)
+            {
+               canId = curMap->canId;
+               offset = curPos->offsetBits;
+               length = curPos->numBits;
+               gain = curPos->gain;
+               return true;
+            }
+         }
+      }
+      done = rx;
+      rx = true;
+   }
+   return false;
+}
+
+void CanMap::IterateCanMap(void (*callback)(Param::PARAM_NUM, uint32_t, uint8_t, uint8_t, float, bool))
+{
+   bool done = false, rx = false;
+
+   for (CANIDMAP *map = canSendMap; !done; map = canRecvMap)
+   {
+      forEachCanMap(curMap, map)
+      {
+         forEachPosMap(curPos, curMap)
+         {
+            callback((Param::PARAM_NUM)curPos->mapParam, curMap->canId, curPos->offsetBits, curPos->numBits, curPos->gain, rx);
+         }
+      }
+      done = rx;
+      rx = true;
+   }
+}
+
+/****************** Private methods and ISRs ********************/
+
+//http://www.byteme.org.uk/canopenparent/canopen/sdo-service-data-objects-canopen/
+void CanMap::ProcessSDO(uint32_t data[2])
+{
+   CAN_SDO *sdo = (CAN_SDO*)data;
+   if (sdo->index >= 0x2000 && sdo->index <= 0x2001 && sdo->subIndex < Param::PARAM_LAST)
+   {
+      Param::PARAM_NUM paramIdx = (Param::PARAM_NUM)sdo->subIndex;
+
+      //SDO index 0x2001 will lookup the parameter by its unique ID
+      if (sdo->index == 0x2001)
+         paramIdx = Param::NumFromId(sdo->subIndex);
+
+      if (sdo->cmd == SDO_WRITE)
+      {
+         if (Param::Set(paramIdx, sdo->data) == 0)
+         {
+            sdo->cmd = SDO_WRITE_REPLY;
+         }
+         else
+         {
+            sdo->cmd = SDO_ABORT;
+            sdo->data = SDO_ERR_RANGE;
+         }
+      }
+      else if (sdo->cmd == SDO_READ)
+      {
+         sdo->data = Param::Get(paramIdx);
+         sdo->cmd = SDO_READ_REPLY;
+      }
+   }
+   else if (sdo->index >= 0x3000 && sdo->index < 0x4800 && sdo->subIndex < Param::PARAM_LAST)
+   {
+      if (sdo->cmd == SDO_WRITE)
+      {
+         int result;
+         int offset = sdo->data & 0xFF;
+         int len = (sdo->data >> 8) & 0xFF;
+         s32fp gain = sdo->data >> 16;
+
+         if ((sdo->index & 0x4000) == 0x4000)
+         {
+            result = AddRecv((Param::PARAM_NUM)sdo->subIndex, sdo->index & 0x7FF, offset, len, gain);
+         }
+         else
+         {
+            result = AddSend((Param::PARAM_NUM)sdo->subIndex, sdo->index & 0x7FF, offset, len, gain);
+         }
+
+         if (result >= 0)
+         {
+            sdo->cmd = SDO_WRITE_REPLY;
+         }
+         else
+         {
+            sdo->cmd = SDO_ABORT;
+            sdo->data = SDO_ERR_RANGE;
+         }
+      }
+   }
+   else
+   {
+      sdo->cmd = SDO_ABORT;
+      sdo->data = SDO_ERR_INVIDX;
+   }
+   canHardware->Send(0x580 + nodeId, data);
+}
+
+void CanMap::ClearMap(CANIDMAP *canMap)
+{
+   for (int i = 0; i < MAX_MESSAGES; i++)
+   {
+      canMap[i].first = MAX_ITEMS;
+   }
+
+   //Initialize also tail to ITEM_UNSET
+   for (int i = 0; i < (MAX_ITEMS + 1); i++)
+   {
+      canPosMap[i].next = ITEM_UNSET;
+   }
+}
+
+int CanMap::RemoveFromMap(CANIDMAP *canMap, Param::PARAM_NUM param)
+{
+   int removed = 0;
+   CANPOS *lastPosMap;
+
+   forEachCanMap(curMap, canMap)
+   {
+      lastPosMap = 0;
+
+      forEachPosMap(curPos, curMap)
+      {
+         if (curPos->mapParam == param)
+         {
+            if (lastPosMap != 0)
+            {
+               lastPosMap->next = curPos->next;
+            }
+            else
+            {
+               curMap->first = curPos->next;
+            }
+         }
+         lastPosMap = curPos;
+      }
+   }
+
+   return removed;
+}
+
+int CanMap::Add(CANIDMAP *canMap, Param::PARAM_NUM param, uint32_t canId, uint8_t offsetBits, uint8_t length, float gain, int8_t offset)
+{
+   if (canId > 0x1fffffff) return CAN_ERR_INVALID_ID;
+   if (offsetBits > 63) return CAN_ERR_INVALID_OFS;
+   if (length > 32) return CAN_ERR_INVALID_LEN;
+
+   CANIDMAP *existingMap = FindById(canMap, canId);
+
+   if (0 == existingMap)
+   {
+      for (int i = 0; i < MAX_MESSAGES; i++)
+      {
+         if (canMap[i].first == MAX_ITEMS)
+         {
+            existingMap = &canMap[i];
+            break;
+         }
+      }
+
+      if (0 == existingMap)
+         return CAN_ERR_MAXMESSAGES;
+
+      existingMap->canId = canId;
+   }
+
+   int freeIndex;
+
+   for (freeIndex = 0; freeIndex < MAX_ITEMS && canPosMap[freeIndex].next != ITEM_UNSET; freeIndex++);
+
+   if (freeIndex == MAX_ITEMS)
+      return CAN_ERR_MAXITEMS;
+
+   CANPOS* precedingItem = 0;
+
+   for (int precedingIndex = existingMap->first; precedingIndex != MAX_ITEMS; precedingIndex = canPosMap[precedingIndex].next)
+      precedingItem = &canPosMap[precedingIndex];
+
+   CANPOS* freeItem = &canPosMap[freeIndex];
+   freeItem->mapParam = param;
+   freeItem->gain = gain;
+   freeItem->offset = offset;
+   freeItem->offsetBits = offsetBits;
+   freeItem->numBits = length;
+   freeItem->next = MAX_ITEMS;
+
+   if (precedingItem == 0) //first item for this can ID
+   {
+      existingMap->first = freeIndex;
+   }
+   else
+   {
+      precedingItem->next = freeIndex;
+   }
+
+   int count = 0;
+
+   forEachCanMap(curMap, canMap)
+      count++;
+
+   return count;
+}
+
+uint32_t CanMap::SaveToFlash(uint32_t baseAddress, uint32_t* data, int len)
+{
+   uint32_t crc = 0;
+
+   for (int idx = 0; idx < len; idx++)
+   {
+      crc = crc_calculate(*data);
+      flash_program_word(baseAddress + idx * sizeof(uint32_t), *data);
+      data++;
+   }
+
+   return crc;
+}
+
+int CanMap::LoadFromFlash()
+{
+   uint32_t baseAddress = GetFlashAddress();
+   uint32_t storedCrc = *(uint32_t*)CRC_ADDRESS(baseAddress);
+   uint32_t crc;
+
+   crc_reset();
+   crc = crc_calculate_block((uint32_t*)baseAddress, SENDMAP_WORDS + RECVMAP_WORDS + POSMAP_WORDS);
+
+   if (storedCrc == crc)
+   {
+      memcpy32((int*)canSendMap, (int*)SENDMAP_ADDRESS(baseAddress), SENDMAP_WORDS);
+      memcpy32((int*)canRecvMap, (int*)RECVMAP_ADDRESS(baseAddress), RECVMAP_WORDS);
+      memcpy32((int*)canPosMap, (int*)POSMAP_ADDRESS(baseAddress), POSMAP_WORDS);
+      ReplaceParamUidByEnum(canSendMap);
+      ReplaceParamUidByEnum(canRecvMap);
+      return 1;
+   }
+   return 0;
+}
+
+CanMap::CANIDMAP* CanMap::FindById(CANIDMAP *canMap, uint32_t canId)
+{
+   forEachCanMap(curMap, canMap)
+   {
+      if (curMap->canId == canId)
+         return curMap;
+   }
+   return 0;
+}
+
+uint32_t CanMap::GetFlashAddress()
+{
+   uint32_t flashSize = desig_get_flash_size();
+
+   return FLASH_BASE + flashSize * 1024 - FLASH_PAGE_SIZE * CAN1_BLKNUM;
+}
+
+void CanMap::ReplaceParamEnumByUid(CANIDMAP *canMap)
+{
+   forEachCanMap(curMap, canMap)
+   {
+      forEachPosMap(curPos, curMap)
+      {
+         const Param::Attributes* attr = Param::GetAttrib((Param::PARAM_NUM)curPos->mapParam);
+         curPos->mapParam = (uint16_t)attr->id;
+      }
+   }
+}
+
+void CanMap::ReplaceParamUidByEnum(CANIDMAP *canMap)
+{
+   forEachCanMap(curMap, canMap)
+   {
+      forEachPosMap(curPos, curMap)
+      {
+         Param::PARAM_NUM param = Param::NumFromId(curPos->mapParam);
+         curPos->mapParam = param;
+      }
+   }
+}

--- a/src/foc.cpp
+++ b/src/foc.cpp
@@ -37,7 +37,7 @@ static const s32fp lqminusld = FP_FROMFLT(0.0058);
 static const u32fp sqrt3 = SQRT3;
 static const s32fp sqrt3inv1 = FP_FROMFLT(0.57735026919); //1/sqrt(3)
 static const s32fp zeroOffset = FP_FROMINT(1);
-static const int32_t modMax = FP_DIV(FP_FROMINT(2U), sqrt3);
+static const int32_t modMax = FP_DIV(FP_FROMINT(2U), sqrt3) - 1500;
 static const int32_t modMaxPow2 = modMax * modMax;
 static const int32_t minPulse = 1000;
 static const int32_t maxPulse = FP_FROMINT(2) - 1000;
@@ -134,11 +134,11 @@ void FOC::InvParkClarke(int32_t ud, int32_t uq)
       /* Short pulse suppression */
       if (DutyCycles[i] < minPulse)
       {
-         DutyCycles[i] = 0U;
+         DutyCycles[i] = minPulse;
       }
       else if (DutyCycles[i] > maxPulse)
       {
-         DutyCycles[i] = FP_FROMINT(2);
+         DutyCycles[i] = maxPulse;
       }
    }
 }

--- a/src/param_save.cpp
+++ b/src/param_save.cpp
@@ -115,7 +115,18 @@ int parm_load()
          Param::PARAM_NUM idx = Param::NumFromId(parmPage->data[idxPage].key);
          if (idx != Param::PARAM_INVALID && parmPage->data[idxPage].key > 0)
          {
-            Param::SetFixed(idx, parmPage->data[idxPage].value);
+            const Param::Attributes *attr = Param::GetAttrib(idx);
+            // If a PARAM_NUM gets reused we can end up with invalid values in flash.
+            // If the value in flash is out of bounds set to default
+            if ((s32fp)parmPage->data[idxPage].value >= attr->min &&
+                (s32fp)parmPage->data[idxPage].value <= attr->max)
+            {
+               Param::SetFixed(idx, parmPage->data[idxPage].value);
+            }
+            else
+            {
+               Param::SetFixed(idx, attr->def);
+            }
             Param::SetFlagsRaw(idx, parmPage->data[idxPage].flags);
          }
       }

--- a/src/stm32_can.cpp
+++ b/src/stm32_can.cpp
@@ -19,16 +19,12 @@
  */
 #include <stdint.h>
 #include "hwdefs.h"
-#include "my_string.h"
 #include "my_math.h"
 #include "printf.h"
 #include <libopencm3/stm32/can.h>
 #include <libopencm3/stm32/gpio.h>
 #include <libopencm3/stm32/rcc.h>
-#include <libopencm3/stm32/flash.h>
-#include <libopencm3/stm32/crc.h>
 #include <libopencm3/stm32/rtc.h>
-#include <libopencm3/stm32/desig.h>
 #include <libopencm3/cm3/common.h>
 #include <libopencm3/cm3/nvic.h>
 #include "stm32_can.h"
@@ -36,40 +32,6 @@
 #define MAX_INTERFACES        2
 #define IDS_PER_BANK          4
 #define EXT_IDS_PER_BANK      2
-#define SDO_WRITE             0x40
-#define SDO_READ              0x22
-#define SDO_ABORT             0x80
-#define SDO_WRITE_REPLY       0x23
-#define SDO_READ_REPLY        0x43
-#define SDO_ERR_INVIDX        0x06020000
-#define SDO_ERR_RANGE         0x06090030
-#define SENDMAP_ADDRESS(b)    b
-#define RECVMAP_ADDRESS(b)    (b + sizeof(canSendMap))
-#define POSMAP_ADDRESS(b)     (b + sizeof(canSendMap) + sizeof(canRecvMap))
-#define CRC_ADDRESS(b)        (b + sizeof(canSendMap) + sizeof(canRecvMap) + sizeof(canPosMap))
-#define SENDMAP_WORDS         (sizeof(canSendMap) / (sizeof(uint32_t)))
-#define RECVMAP_WORDS         (sizeof(canRecvMap) / (sizeof(uint32_t)))
-#define POSMAP_WORDS          ((sizeof(CANPOS) * MAX_ITEMS) / (sizeof(uint32_t)))
-#define ITEM_UNSET            0xff
-#define forEachCanMap(c,m) for (CANIDMAP *c = m; (c - m) < MAX_MESSAGES && c->first != MAX_ITEMS; c++)
-#define forEachPosMap(c,m) for (CANPOS *c = &canPosMap[m->first]; c->next != ITEM_UNSET; c = &canPosMap[c->next])
-
-#ifdef CAN_EXT
-#define IDMAPSIZE 8
-#else
-#define IDMAPSIZE 4
-#endif // CAN_EXT
-#if (MAX_ITEMS * 12 + 2 * MAX_MESSAGES * IDMAPSIZE + 4) > FLASH_PAGE_SIZE
-#error CANMAP will not fit in one flash page
-#endif
-
-struct CAN_SDO
-{
-   uint8_t cmd;
-   uint16_t index;
-   uint8_t subIndex;
-   uint32_t data;
-} __attribute__((packed));
 
 struct CANSPEED
 {
@@ -78,11 +40,9 @@ struct CANSPEED
    uint32_t prescaler;
 };
 
-Can* Can::interfaces[MAX_INTERFACES];
-volatile bool Can::isSaving = false;
+Stm32Can* Stm32Can::interfaces[MAX_INTERFACES];
 
-static void DummyCallback(uint32_t i, uint32_t* d) { i=i; d=d; }
-static const CANSPEED canSpeed[Can::BaudLast] =
+static const CANSPEED canSpeed[CanHardware::BaudLast] =
 {
    { CAN_BTR_TS1_9TQ, CAN_BTR_TS2_6TQ, 18}, //125kbps
    { CAN_BTR_TS1_9TQ, CAN_BTR_TS2_6TQ, 9 }, //250kbps
@@ -91,225 +51,6 @@ static const CANSPEED canSpeed[Can::BaudLast] =
    { CAN_BTR_TS1_6TQ, CAN_BTR_TS2_5TQ, 3 }, //1000kbps
 };
 
-/** \brief Add periodic CAN message
- *
- * \param param Parameter index of parameter to be sent
- * \param canId CAN identifier of generated message
- * \param offset bit offset within the 64 message bits
- * \param length number of bits
- * \param gain Fixed point gain to be multiplied before sending
- * \return success: number of active messages
- * Fault:
- * - CAN_ERR_INVALID_ID ID was > 0x1fffffff
- * - CAN_ERR_INVALID_OFS Offset > 63
- * - CAN_ERR_INVALID_LEN Length > 32
- * - CAN_ERR_MAXMESSAGES Already 10 send messages defined
- * - CAN_ERR_MAXITEMS Already than MAX_ITEMS items total defined
- */
-int Can::AddSend(Param::PARAM_NUM param, uint32_t canId, uint8_t offsetBits, uint8_t length, float gain, int8_t offset)
-{
-   return Add(canSendMap, param, canId, offsetBits, length, gain, offset);
-}
-
-int Can::AddSend(Param::PARAM_NUM param, uint32_t canId, uint8_t offsetBits, uint8_t length, float gain)
-{
-   return Add(canSendMap, param, canId, offsetBits, length, gain, 0);
-}
-
-/** \brief Map data from CAN bus to parameter
- *
- * \param param Parameter index of parameter to be received
- * \param canId CAN identifier of consumed message
- * \param offset bit offset within the 64 message bits
- * \param length number of bits
- * \param gain Fixed point gain to be multiplied after receiving
- * \return success: number of active messages
- * Fault:
- * - CAN_ERR_INVALID_ID ID was > 0x1fffffff
- * - CAN_ERR_INVALID_OFS Offset > 63
- * - CAN_ERR_INVALID_LEN Length > 32
- * - CAN_ERR_MAXMESSAGES Already 10 receive messages defined
- * - CAN_ERR_MAXITEMS Already than MAX_ITEMS items total defined
- */
-int Can::AddRecv(Param::PARAM_NUM param, uint32_t canId, uint8_t offsetBits, uint8_t length, float gain, int8_t offset)
-{
-   int res = Add(canRecvMap, param, canId, offsetBits, length, gain, offset);
-   ConfigureFilters();
-   return res;
-}
-
-int Can::AddRecv(Param::PARAM_NUM param, uint32_t canId, uint8_t offsetBits, uint8_t length, float gain)
-{
-   return Can::AddRecv(param, canId, offsetBits, length, gain, 0);
-}
-
-/** \brief Set function to be called for user handled CAN messages
- *
- * \param recv Function pointer to void func(uint32_t, uint32_t[2]) - ID, Data
- */
-void Can::SetReceiveCallback(void (*recv)(uint32_t, uint32_t*))
-{
-   recvCallback = recv;
-}
-
-/** \brief Add CAN Id to user message list
- * \post Receive callback will be called when a message with this Id id received
- * \param canId CAN identifier of message to be user handled
- * \return true: success, false: already 10 messages registered
- *
- */
-bool Can::RegisterUserMessage(uint32_t canId)
-{
-   if (nextUserMessageIndex < MAX_USER_MESSAGES)
-   {
-      userIds[nextUserMessageIndex] = canId;
-      nextUserMessageIndex++;
-      ConfigureFilters();
-      return true;
-   }
-   return false;
-}
-
-/** \brief Remove all CAN Id from user message list
- */
-void Can::ClearUserMessages()
-{
-   nextUserMessageIndex = 0;
-   ConfigureFilters();
-}
-
-/** \brief Find first occurence of parameter in CAN map and output its mapping info
- *
- * Memory layout: SendMap, RecvMap, PosMap, CRC
- * Send/Recv maps point to items in PosMap. PosMap may point to next item
- *
- * \param[in] param Index of parameter to be looked up
- * \param[out] canId CAN identifier that the parameter is mapped to
- * \param[out] offset bit offset that the parameter is mapped to
- * \param[out] length number of bits that the parameter is mapped to
- * \param[out] gain Parameter gain
- * \param[out] rx true: Parameter is received via CAN, false: sent via CAN
- * \return true: parameter is mapped, false: not mapped
- */
-bool Can::FindMap(Param::PARAM_NUM param, uint32_t& canId, uint8_t& offset, uint8_t& length, float& gain, bool& rx)
-{
-   rx = false;
-   bool done = false;
-
-   for (CANIDMAP *map = canSendMap; !done; map = canRecvMap)
-   {
-      forEachCanMap(curMap, map)
-      {
-         forEachPosMap(curPos, curMap)
-         {
-            if (curPos->mapParam == param)
-            {
-               canId = curMap->canId;
-               offset = curPos->offsetBits;
-               length = curPos->numBits;
-               gain = curPos->gain;
-               return true;
-            }
-         }
-      }
-      done = rx;
-      rx = true;
-   }
-   return false;
-}
-
-/** \brief Save CAN mapping to flash
- */
-void Can::Save()
-{
-   uint32_t crc;
-   uint32_t check = 0xFFFFFFFF;
-   uint32_t baseAddress = GetFlashAddress();
-   uint32_t *checkAddress = (uint32_t*)baseAddress;
-
-   isSaving = true;
-
-   for (int i = 0; i < FLASH_PAGE_SIZE / 4; i++, checkAddress++)
-      check &= *checkAddress;
-
-   crc_reset();
-
-   flash_unlock();
-   flash_set_ws(2);
-
-   if (check != 0xFFFFFFFF) //Only erase when needed
-      flash_erase_page(baseAddress);
-
-   ReplaceParamEnumByUid(canSendMap);
-   ReplaceParamEnumByUid(canRecvMap);
-
-   SaveToFlash(SENDMAP_ADDRESS(baseAddress), (uint32_t *)canSendMap, SENDMAP_WORDS);
-   crc = SaveToFlash(RECVMAP_ADDRESS(baseAddress), (uint32_t *)canRecvMap, RECVMAP_WORDS);
-   crc = SaveToFlash(POSMAP_ADDRESS(baseAddress), (uint32_t *)canPosMap, POSMAP_WORDS);
-   SaveToFlash(CRC_ADDRESS(baseAddress), &crc, 1);
-   flash_lock();
-
-   ReplaceParamUidByEnum(canSendMap);
-   ReplaceParamUidByEnum(canRecvMap);
-
-   isSaving = false;
-}
-
-/** \brief Send all defined messages
- */
-void Can::SendAll()
-{
-   forEachCanMap(curMap, canSendMap)
-   {
-      uint32_t data[2] = { 0 }; //Had an issue with uint64_t, otherwise would have used that
-
-      forEachPosMap(curPos, curMap)
-      {
-         if (isSaving) return; //Only send mapped messages when not currently saving to flash
-
-         float val = Param::GetFloat((Param::PARAM_NUM)curPos->mapParam);
-
-         val *= curPos->gain;
-         val += curPos->offset;
-         int ival = val;
-         ival &= ((1 << curPos->numBits) - 1);
-
-         if (curPos->offsetBits > 31)
-         {
-            data[1] |= ival << (curPos->offsetBits - 32);
-         }
-         else
-         {
-            data[0] |= ival << curPos->offsetBits;
-         }
-      }
-
-      Send(curMap->canId, data);
-   }
-}
-
-/** \brief Clear all defined messages
- */
-void Can::Clear()
-{
-   ClearMap(canSendMap);
-   ClearMap(canRecvMap);
-   ConfigureFilters();
-}
-
-/** \brief Remove all occurences of given parameter from CAN map
- *
- * \param param Parameter index to be removed
- * \return int number of removed items
- *
- */
-int Can::Remove(Param::PARAM_NUM param)
-{
-   int removed = RemoveFromMap(canSendMap, param);
-   removed += RemoveFromMap(canRecvMap, param);
-
-   return removed;
-}
 
 /** \brief Init can hardware with given baud rate
  * Initializes the following sub systems:
@@ -323,12 +64,9 @@ int Can::Remove(Param::PARAM_NUM param)
  * \return void
  *
  */
-Can::Can(uint32_t baseAddr, enum baudrates baudrate, bool remap)
-   : lastRxTimestamp(0), sendCnt(0), recvCallback(DummyCallback), nextUserMessageIndex(0), canDev(baseAddr)
+Stm32Can::Stm32Can(uint32_t baseAddr, enum baudrates baudrate, bool remap)
+   : sendCnt(0), canDev(baseAddr)
 {
-   Clear();
-   LoadFromFlash();
-
    switch (baseAddr)
    {
       case CAN1:
@@ -387,7 +125,6 @@ Can::Can(uint32_t baseAddr, enum baudrates baudrate, bool remap)
          break;
    }
 
-   nodeId = 1;
 	// Reset CAN
 	can_reset(canDev);
 
@@ -404,7 +141,7 @@ Can::Can(uint32_t baseAddr, enum baudrates baudrate, bool remap)
  * \return void
  *
  */
-void Can::SetBaudrate(enum baudrates baudrate)
+void Stm32Can::SetBaudrate(enum baudrates baudrate)
 {
 	// CAN cell init.
 	 // Setting the bitrate to 250KBit. APB1 = 36MHz,
@@ -427,16 +164,6 @@ void Can::SetBaudrate(enum baudrates baudrate)
 		     false);
 }
 
-/** \brief Get RTC time when last message was received
- *
- * \return uint32_t RTC time
- *
- */
-uint32_t Can::GetLastRxTimestamp()
-{
-   return lastRxTimestamp;
-}
-
 /** \brief Send a user defined CAN message
  *
  * \param canId uint32_t
@@ -445,7 +172,7 @@ uint32_t Can::GetLastRxTimestamp()
  * \return void
  *
  */
-void Can::Send(uint32_t canId, uint32_t data[2], uint8_t len)
+void Stm32Can::Send(uint32_t canId, uint32_t data[2], uint8_t len)
 {
    can_disable_irq(canDev, CAN_IER_TMEIE);
 
@@ -465,25 +192,7 @@ void Can::Send(uint32_t canId, uint32_t data[2], uint8_t len)
    }
 }
 
-void Can::IterateCanMap(void (*callback)(Param::PARAM_NUM, uint32_t, uint8_t, uint8_t, float, bool))
-{
-   bool done = false, rx = false;
-
-   for (CANIDMAP *map = canSendMap; !done; map = canRecvMap)
-   {
-      forEachCanMap(curMap, map)
-      {
-         forEachPosMap(curPos, curMap)
-         {
-            callback((Param::PARAM_NUM)curPos->mapParam, curMap->canId, curPos->offsetBits, curPos->numBits, curPos->gain, rx);
-         }
-      }
-      done = rx;
-      rx = true;
-   }
-}
-
-Can* Can::GetInterface(int index)
+Stm32Can* Stm32Can::GetInterface(int index)
 {
    if (index < MAX_INTERFACES)
    {
@@ -492,59 +201,21 @@ Can* Can::GetInterface(int index)
    return 0;
 }
 
-void Can::HandleRx(int fifo)
+void Stm32Can::HandleMessage(int fifo)
 {
    uint32_t id;
 	bool ext, rtr;
 	uint8_t length, fmi;
 	uint32_t data[2];
 
-   while (can_receive(canDev, fifo, true, &id, &ext, &rtr, &fmi, &length, (uint8_t*)data, NULL) > 0)
+   while (can_receive(canDev, fifo, true, &id, &ext, &rtr, &fmi, &length, (uint8_t*)data, 0) > 0)
    {
-      //printf("fifo: %d, id: %x, len: %d, data[0]: %x, data[1]: %x\r\n", fifo, id, length, data[0], data[1]);
-      if (id == (0x600U + nodeId) && length == 8) //SDO request
-      {
-         ProcessSDO(data);
-      }
-      else
-      {
-         if (isSaving) continue; //Only handle mapped messages when not currently saving to flash
-
-         CANIDMAP *recvMap = FindById(canRecvMap, id);
-
-         if (0 != recvMap)
-         {
-            forEachPosMap(curPos, recvMap)
-            {
-               float val;
-
-               if (curPos->offsetBits > 31)
-               {
-                  val = (data[1] >> (curPos->offsetBits - 32)) & ((1 << curPos->numBits) - 1);
-               }
-               else
-               {
-                  val = (data[0] >> curPos->offsetBits) & ((1 << curPos->numBits) - 1);
-               }
-               val += curPos->offset;
-               val *= curPos->gain;
-
-               if (Param::IsParam((Param::PARAM_NUM)curPos->mapParam))
-                  Param::Set((Param::PARAM_NUM)curPos->mapParam, FP_FROMFLT(val));
-               else
-                  Param::SetFloat((Param::PARAM_NUM)curPos->mapParam, val);
-            }
-            lastRxTimestamp = rtc_get_counter_val();
-         }
-         else //Now it must be a user message, as filters block everything else
-         {
-            recvCallback(id, data);
-         }
-      }
+      HandleRx(id, data);
+      lastRxTimestamp = rtc_get_counter_val();
    }
 }
 
-void Can::HandleTx()
+void Stm32Can::HandleTx()
 {
    SENDBUFFER* b = sendBuffer; //alias
 
@@ -557,89 +228,9 @@ void Can::HandleTx()
    }
 }
 
-void Can::SDOWrite(uint8_t remoteNodeId, uint16_t index, uint8_t subIndex, uint32_t data)
-{
-   uint32_t d[2];
-   CAN_SDO *sdo = (CAN_SDO*)d;
-
-   sdo->cmd = SDO_WRITE;
-   sdo->index = index;
-   sdo->subIndex = subIndex;
-   sdo->data = data;
-
-   Send(0x600 + remoteNodeId, d);
-}
-
 /****************** Private methods and ISRs ********************/
 
-//http://www.byteme.org.uk/canopenparent/canopen/sdo-service-data-objects-canopen/
-void Can::ProcessSDO(uint32_t data[2])
-{
-   CAN_SDO *sdo = (CAN_SDO*)data;
-   if (sdo->index >= 0x2000 && sdo->index <= 0x2001 && sdo->subIndex < Param::PARAM_LAST)
-   {
-      Param::PARAM_NUM paramIdx = (Param::PARAM_NUM)sdo->subIndex;
-
-      //SDO index 0x2001 will lookup the parameter by its unique ID
-      if (sdo->index == 0x2001)
-         paramIdx = Param::NumFromId(sdo->subIndex);
-
-      if (sdo->cmd == SDO_WRITE)
-      {
-         if (Param::Set(paramIdx, sdo->data) == 0)
-         {
-            sdo->cmd = SDO_WRITE_REPLY;
-         }
-         else
-         {
-            sdo->cmd = SDO_ABORT;
-            sdo->data = SDO_ERR_RANGE;
-         }
-      }
-      else if (sdo->cmd == SDO_READ)
-      {
-         sdo->data = Param::Get(paramIdx);
-         sdo->cmd = SDO_READ_REPLY;
-      }
-   }
-   else if (sdo->index >= 0x3000 && sdo->index < 0x4800 && sdo->subIndex < Param::PARAM_LAST)
-   {
-      if (sdo->cmd == SDO_WRITE)
-      {
-         int result;
-         int offset = sdo->data & 0xFF;
-         int len = (sdo->data >> 8) & 0xFF;
-         s32fp gain = sdo->data >> 16;
-
-         if ((sdo->index & 0x4000) == 0x4000)
-         {
-            result = Can::AddRecv((Param::PARAM_NUM)sdo->subIndex, sdo->index & 0x7FF, offset, len, gain);
-         }
-         else
-         {
-            result = Can::AddSend((Param::PARAM_NUM)sdo->subIndex, sdo->index & 0x7FF, offset, len, gain);
-         }
-
-         if (result >= 0)
-         {
-            sdo->cmd = SDO_WRITE_REPLY;
-         }
-         else
-         {
-            sdo->cmd = SDO_ABORT;
-            sdo->data = SDO_ERR_RANGE;
-         }
-      }
-   }
-   else
-   {
-      sdo->cmd = SDO_ABORT;
-      sdo->data = SDO_ERR_INVIDX;
-   }
-   Can::Send(0x580 + nodeId, data);
-}
-
-void Can::SetFilterBank(int& idIndex, int& filterId, uint16_t* idList)
+void Stm32Can::SetFilterBank(int& idIndex, int& filterId, uint16_t* idList)
 {
    can_filter_id_list_16bit_init(
          filterId,
@@ -654,7 +245,7 @@ void Can::SetFilterBank(int& idIndex, int& filterId, uint16_t* idList)
    idList[0] = idList[1] = idList[2] = idList[3] = 0;
 }
 
-void Can::SetFilterBank29(int& idIndex, int& filterId, uint32_t* idList)
+void Stm32Can::SetFilterBank29(int& idIndex, int& filterId, uint32_t* idList)
 {
    can_filter_id_list_32bit_init(
          filterId,
@@ -667,7 +258,7 @@ void Can::SetFilterBank29(int& idIndex, int& filterId, uint32_t* idList)
    idList[0] = idList[1] = 0;
 }
 
-void Can::ConfigureFilters()
+void Stm32Can::ConfigureFilters()
 {
    uint16_t idList[IDS_PER_BANK] = { 0, 0, 0, 0 };
    uint32_t extIdList[EXT_IDS_PER_BANK] = { 0, 0 };
@@ -697,29 +288,6 @@ void Can::ConfigureFilters()
       }
    }
 
-   forEachCanMap(curMap, canRecvMap)
-   {
-      if (curMap->canId > 0x7ff)
-      {
-         extIdList[extIdIndex] = curMap->canId;
-         extIdIndex++;
-      }
-      else
-      {
-         idList[idIndex] = curMap->canId;
-         idIndex++;
-      }
-
-      if (idIndex == IDS_PER_BANK)
-      {
-         SetFilterBank(idIndex, filterId, idList);
-      }
-      if (extIdIndex == EXT_IDS_PER_BANK)
-      {
-         SetFilterBank29(extIdIndex, filterId, extIdList);
-      }
-   }
-
    //loop terminates before adding last set of filters
    if (idIndex > 0)
    {
@@ -731,248 +299,33 @@ void Can::ConfigureFilters()
    }
 }
 
-int Can::LoadFromFlash()
-{
-   uint32_t baseAddress = GetFlashAddress();
-   uint32_t storedCrc = *(uint32_t*)CRC_ADDRESS(baseAddress);
-   uint32_t crc;
-
-   crc_reset();
-   crc = crc_calculate_block((uint32_t*)baseAddress, SENDMAP_WORDS + RECVMAP_WORDS + POSMAP_WORDS);
-
-   if (storedCrc == crc)
-   {
-      memcpy32((int*)canSendMap, (int*)SENDMAP_ADDRESS(baseAddress), SENDMAP_WORDS);
-      memcpy32((int*)canRecvMap, (int*)RECVMAP_ADDRESS(baseAddress), RECVMAP_WORDS);
-      memcpy32((int*)canPosMap, (int*)POSMAP_ADDRESS(baseAddress), POSMAP_WORDS);
-      ReplaceParamUidByEnum(canSendMap);
-      ReplaceParamUidByEnum(canRecvMap);
-      return 1;
-   }
-   return 0;
-}
-
-int Can::RemoveFromMap(CANIDMAP *canMap, Param::PARAM_NUM param)
-{
-   int removed = 0;
-   CANPOS *lastPosMap;
-
-   forEachCanMap(curMap, canMap)
-   {
-      lastPosMap = 0;
-
-      forEachPosMap(curPos, curMap)
-      {
-         if (curPos->mapParam == param)
-         {
-            if (lastPosMap != 0)
-            {
-               lastPosMap->next = curPos->next;
-            }
-            else
-            {
-               curMap->first = curPos->next;
-            }
-         }
-         lastPosMap = curPos;
-      }
-   }
-
-   return removed;
-}
-
-int Can::Add(CANIDMAP *canMap, Param::PARAM_NUM param, uint32_t canId, uint8_t offsetBits, uint8_t length, float gain, int8_t offset)
-{
-   if (canId > 0x1fffffff) return CAN_ERR_INVALID_ID;
-   if (offsetBits > 63) return CAN_ERR_INVALID_OFS;
-   if (length > 32) return CAN_ERR_INVALID_LEN;
-
-   CANIDMAP *existingMap = FindById(canMap, canId);
-
-   if (0 == existingMap)
-   {
-      for (int i = 0; i < MAX_MESSAGES; i++)
-      {
-         if (canMap[i].first == MAX_ITEMS)
-         {
-            existingMap = &canMap[i];
-            break;
-         }
-      }
-
-      if (0 == existingMap)
-         return CAN_ERR_MAXMESSAGES;
-
-      existingMap->canId = canId;
-   }
-
-   int freeIndex;
-
-   for (freeIndex = 0; freeIndex < MAX_ITEMS && canPosMap[freeIndex].next != ITEM_UNSET; freeIndex++);
-
-   if (freeIndex == MAX_ITEMS)
-      return CAN_ERR_MAXITEMS;
-
-   CANPOS* precedingItem = 0;
-
-   for (int precedingIndex = existingMap->first; precedingIndex != MAX_ITEMS; precedingIndex = canPosMap[precedingIndex].next)
-      precedingItem = &canPosMap[precedingIndex];
-
-   CANPOS* freeItem = &canPosMap[freeIndex];
-   freeItem->mapParam = param;
-   freeItem->gain = gain;
-   freeItem->offset = offset;
-   freeItem->offsetBits = offsetBits;
-   freeItem->numBits = length;
-   freeItem->next = MAX_ITEMS;
-
-   if (precedingItem == 0) //first item for this can ID
-   {
-      existingMap->first = freeIndex;
-   }
-   else
-   {
-      precedingItem->next = freeIndex;
-   }
-
-   int count = 0;
-
-   forEachCanMap(curMap, canMap)
-      count++;
-
-   return count;
-}
-
-void Can::ClearMap(CANIDMAP *canMap)
-{
-   for (int i = 0; i < MAX_MESSAGES; i++)
-   {
-      canMap[i].first = MAX_ITEMS;
-   }
-
-   //Initialize also tail to ITEM_UNSET
-   for (int i = 0; i < (MAX_ITEMS + 1); i++)
-   {
-      canPosMap[i].next = ITEM_UNSET;
-   }
-}
-
-Can::CANIDMAP* Can::FindById(CANIDMAP *canMap, uint32_t canId)
-{
-   forEachCanMap(curMap, canMap)
-   {
-      if (curMap->canId == canId)
-         return curMap;
-   }
-   return 0;
-}
-
-uint32_t Can::SaveToFlash(uint32_t baseAddress, uint32_t* data, int len)
-{
-   uint32_t crc = 0;
-
-   for (int idx = 0; idx < len; idx++)
-   {
-      crc = crc_calculate(*data);
-      flash_program_word(baseAddress + idx * sizeof(uint32_t), *data);
-      data++;
-   }
-
-   return crc;
-}
-
-int Can::CopyIdMapExcept(CANIDMAP *source, CANIDMAP *dest, Param::PARAM_NUM param)
-{
-   int i = 0, removed = 0;
-   int j = 0;
-
-   forEachCanMap(curMap, source)
-   {
-      bool discardId = true;
-
-      forEachPosMap(curPos, curMap)
-      {
-         if (curPos->mapParam != param)
-         {
-            discardId = false;
-            canPosMap[j] = *curPos;
-            j++;
-         }
-         else
-         {
-            removed++;
-         }
-      }
-
-      if (!discardId)
-      {
-         dest[i].canId = curMap->canId;
-         i++;
-      }
-   }
-
-   return removed;
-}
-
-void Can::ReplaceParamEnumByUid(CANIDMAP *canMap)
-{
-   forEachCanMap(curMap, canMap)
-   {
-      forEachPosMap(curPos, curMap)
-      {
-         const Param::Attributes* attr = Param::GetAttrib((Param::PARAM_NUM)curPos->mapParam);
-         curPos->mapParam = (uint16_t)attr->id;
-      }
-   }
-}
-
-void Can::ReplaceParamUidByEnum(CANIDMAP *canMap)
-{
-   forEachCanMap(curMap, canMap)
-   {
-      forEachPosMap(curPos, curMap)
-      {
-         Param::PARAM_NUM param = Param::NumFromId(curPos->mapParam);
-         curPos->mapParam = param;
-      }
-   }
-}
-
-uint32_t Can::GetFlashAddress()
-{
-   uint32_t flashSize = desig_get_flash_size();
-
-   //Always save CAN mapping to second-to-last flash page
-   return FLASH_BASE + flashSize * 1024 - FLASH_PAGE_SIZE * (canDev == CAN1 ? CAN1_BLKNUM : CAN2_BLKNUM);
-}
-
 /* Interrupt service routines */
 extern "C" void usb_lp_can_rx0_isr(void)
 {
-   Can::GetInterface(0)->HandleRx(0);
+   Stm32Can::GetInterface(0)->HandleMessage(0);
 }
 
 extern "C" void can_rx1_isr()
 {
-   Can::GetInterface(0)->HandleRx(1);
+   Stm32Can::GetInterface(0)->HandleMessage(1);
 }
 
 extern "C" void usb_hp_can_tx_isr()
 {
-   Can::GetInterface(0)->HandleTx();
+   Stm32Can::GetInterface(0)->HandleTx();
 }
 
 extern "C" void can2_rx0_isr()
 {
-   Can::GetInterface(1)->HandleRx(0);
+   Stm32Can::GetInterface(1)->HandleMessage(0);
 }
 
 extern "C" void can2_rx1_isr()
 {
-   Can::GetInterface(1)->HandleRx(1);
+   Stm32Can::GetInterface(1)->HandleMessage(1);
 }
 
 extern "C" void can2_tx_isr()
 {
-   Can::GetInterface(1)->HandleTx();
+   Stm32Can::GetInterface(1)->HandleTx();
 }


### PR DESCRIPTION
Add bounds checking when loading params from flash.  If a PARAM_NUM gets reused it can cause really hard to debug behavior/crashes.