### PR TITLE
Add fp_hypot2 and fp_hypot3 functions to safely calculate square root of sums of squares

### DIFF
--- a/include/my_fp.h
+++ b/include/my_fp.h
@@ -57,6 +57,8 @@ char* fp_itoa(char * buf, s32fp a);
 s32fp fp_atoi(const char *str, int fracDigits);
 u32fp fp_sqrt(u32fp rad);
 s32fp fp_ln(unsigned int x);
+u32fp fp_hypot2(s32fp a, s32fp b);
+u32fp fp_hypot3(s32fp a, s32fp b, s32fp c);
 
 #ifdef __cplusplus
 }

--- a/src/my_fp.c
+++ b/src/my_fp.c
@@ -139,3 +139,32 @@ static s32fp log2_approx(s32fp x, int loopLimit)
 
    return result;
 }
+
+// Calculate the square root of the sum of two squares
+// This scales down the inputs as much as necessary to avoid overflow
+u32fp fp_hypot2(s32fp a, s32fp b)
+{
+  int n = 0;
+  while(a > 16383 || b > 16383 || a < -16383 || b < -16383) {
+    n++;
+    a /= 2;
+    b /= 2;
+  }
+  u32fp result = fp_sqrt(FP_MUL(a,a) + FP_MUL(b,b));
+  return result << n;
+}
+
+// Calculate the square root of the sum on three squares
+// This scales down the inputs as much as necessary to avoid overflow
+u32fp fp_hypot3(s32fp a, s32fp b, s32fp c)
+{
+  int n = 0;
+  while(a > 16383 || b > 16383 || c > 16383 || a < -16383 || b < -16383 || c < -16383) {
+    n++;
+    a /= 2;
+    b /= 2;
+    c /= 2;
+  }
+  u32fp result = fp_sqrt(FP_MUL(a,a) + FP_MUL(b,b) + FP_MUL(c,c));
+  return result << n;
+}


### PR DESCRIPTION
These functions find the square root of the sums of squares. The input values are scaled down by as much as is required to guarantee the multiplications and additions cannot overflow a 32 bit integer and the result is scaled up accordingly. The loss of precision is minimal.