### PR TITLE
Allow CAN SDO to return parameters to defaults

### DIFF
--- a/src/canmap.cpp
+++ b/src/canmap.cpp
@@ -53,6 +53,7 @@
 #define SDO_CMD_SAVE          0
 #define SDO_CMD_LOAD          1
 #define SDO_CMD_RESET         2
+#define SDO_CMD_DEFAULTS      3
 
 #define SENDMAP_ADDRESS(b)    b
 #define RECVMAP_ADDRESS(b)    (b + sizeof(canSendMap))
@@ -521,6 +522,10 @@ void CanMap::ProcessSpecialSDOObjects(CAN_SDO* sdo)
          break;
       case SDO_CMD_RESET:
          scb_reset_system();
+         break;
+      case SDO_CMD_DEFAULTS:
+         Param::LoadDefaults();
+         Param::Change(Param::PARAM_LAST);
          break;
       default:
          sdo->cmd = SDO_ABORT;


### PR DESCRIPTION
Add a new command that resets all parameters to
defaults.

Tests:
 - Build into stm32-sine new_can_module branch
 - Run:

```text
oic write brakeregen -13.4 # modify a parameter
oic read brakeregen # verify the parameter has been set 
oic cmd defaults
oic read brakeregen # verify the parameter has been returned to the default (-50.0)
```