### PR TITLE
CAN mapping fixes

### DIFF
--- a/src/canmap.cpp
+++ b/src/canmap.cpp
@@ -168,23 +168,47 @@ void CanMap::SendAll()
          // convert to a signed integer value before storing in an unsigned to
          // avoid sign-extension problems when we start shifting and masking
          uint32_t ival = (int32_t)val;
-         ival &= ((1UL << curPos->numBits) - 1);
+         uint8_t numBits = ABS(curPos->numBits);
+         ival &= (1UL << numBits) - 1;
 
-         if (curPos->offsetBits > 31)
+         if (curPos->numBits < 0) // big-endian
          {
-            // data entirely in the second word
-            data[1] |= ival << (curPos->offsetBits - 32);
+            //Swap byte order
+            const uint8_t* bptr = (uint8_t*)&ival;
+            ival = (bptr[0] << 24) | (bptr[1] << 16) | (bptr[2] << 8) | bptr[3];
+
+            if (curPos->offsetBits < 32) //all data in first word
+            {
+               data[0] |= ival >> (31 - curPos->offsetBits);
+            }
+            else if ((curPos->offsetBits + curPos->numBits) >= 31) //all data in second word
+            {
+               data[1] |= ival >> (63 - curPos->offsetBits);
+            }
+            else //data spans across both words
+            {
+               data[0] |= ival << (curPos->offsetBits - 31);
+               data[1] |= ival >> (63 - curPos->offsetBits);
+            }
          }
-         else if ((curPos->offsetBits + curPos->numBits) <= 32)
+         else // little-endian
          {
-            // data entirely in the first word
-            data[0] |= ival << curPos->offsetBits;
-         }
-         else
-         {
-            // data spans both words
-            data[0] |= ival << curPos->offsetBits;
-            data[1] |= ival >> (32 - curPos->offsetBits);
+            if (curPos->offsetBits > 31)
+            {
+               // data entirely in the second word
+               data[1] |= ival << (curPos->offsetBits - 32);
+            }
+            else if ((curPos->offsetBits + curPos->numBits) <= 32)
+            {
+               // data entirely in the first word
+               data[0] |= ival << curPos->offsetBits;
+            }
+            else
+            {
+               // data spans both words
+               data[0] |= ival << curPos->offsetBits;
+               data[1] |= ival >> (32 - curPos->offsetBits);
+            }
          }
       }
 

--- a/src/canmap.cpp
+++ b/src/canmap.cpp
@@ -453,8 +453,8 @@ void CanMap::ClearMap(CANIDMAP *canMap)
 int CanMap::Add(CANIDMAP *canMap, Param::PARAM_NUM param, uint32_t canId, uint8_t offsetBits, int8_t length, float gain, int8_t offset)
 {
    if (canId > MAX_COB_ID) return CAN_ERR_INVALID_ID;
-   if (offsetBits > 63) return CAN_ERR_INVALID_OFS;
-   if (length > 32 || length < -32) return CAN_ERR_INVALID_LEN;
+   if (offsetBits + ABS(length) - 1 > 63) return CAN_ERR_INVALID_OFS;
+   if (length == 0 || ABS(length) > 32) return CAN_ERR_INVALID_LEN;
 
    CANIDMAP *existingMap = FindById(canMap, canId);
 

--- a/src/canmap.cpp
+++ b/src/canmap.cpp
@@ -168,14 +168,14 @@ void CanMap::SendAll()
          // convert to a signed integer value before storing in an unsigned to
          // avoid sign-extension problems when we start shifting and masking
          uint32_t ival = (int32_t)val;
-         ival &= ((1 << curPos->numBits) - 1);
+         ival &= ((1UL << curPos->numBits) - 1);
 
          if (curPos->offsetBits > 31)
          {
             // data entirely in the second word
             data[1] |= ival << (curPos->offsetBits - 32);
          }
-         else if ((curPos->offsetBits + curPos->numBits) < 32)
+         else if ((curPos->offsetBits + curPos->numBits) <= 32)
          {
             // data entirely in the first word
             data[0] |= ival << curPos->offsetBits;

--- a/src/canmap.cpp
+++ b/src/canmap.cpp
@@ -463,8 +463,18 @@ void CanMap::ClearMap(CANIDMAP *canMap)
 int CanMap::Add(CANIDMAP *canMap, Param::PARAM_NUM param, uint32_t canId, uint8_t offsetBits, int8_t length, float gain, int8_t offset)
 {
    if (canId > MAX_COB_ID) return CAN_ERR_INVALID_ID;
-   if (offsetBits + ABS(length) - 1 > 63) return CAN_ERR_INVALID_OFS;
    if (length == 0 || ABS(length) > 32) return CAN_ERR_INVALID_LEN;
+   if (length > 0)
+   {
+      // little-endian mapping
+      if (offsetBits + length - 1 > 63) return CAN_ERR_INVALID_OFS;
+   }
+   else
+   {
+      // big-endian mapping
+      if (offsetBits > 63) return CAN_ERR_INVALID_OFS;
+      if (static_cast<int8_t>(offsetBits) + length + 1 < 0) return CAN_ERR_INVALID_OFS;
+   }
 
    CANIDMAP *existingMap = FindById(canMap, canId);
 


### PR DESCRIPTION
Fix a variety of bugs in can param mapping:
 - Allow signed gains configured via CAN SDO. This matches terminal/web interface configured mapping capability.
 - Ensure that only valid can mappings can be created
 - Allow mappings which overlap the internal 32-bit data structure used to contain a CAN frame to work
 - Implement big-endian can tx mappings
 - Ensure that can rx mappings store valid data for negative numbers

The guiding principle behind these fixes is that if you can configure it via terminal or CAN SDO then it should now work. If you can't configure something it is because it is not expected to work.
