### PR TITLE
To fix #20 make all CAN handlers fire every time

### DIFF
--- a/include/canhardware.h
+++ b/include/canhardware.h
@@ -32,7 +32,7 @@
 class CanCallback
 {
 public:
-   virtual bool HandleRx(uint32_t canId, uint32_t data[2], uint8_t dlc) = 0;
+   virtual void HandleRx(uint32_t canId, uint32_t data[2], uint8_t dlc) = 0;
    virtual void HandleClear() = 0;
 };
 
@@ -40,8 +40,8 @@ class FunctionPointerCallback: public CanCallback
 {
 public:
    FunctionPointerCallback(bool (*r)(uint32_t, uint32_t*, uint8_t), void (*c)()) : recv(r), clear(c) { };
-   bool HandleRx(uint32_t canId, uint32_t data[2], uint8_t dlc) { return recv(canId, data, dlc); }
-   void HandleClear() { clear(); }
+   void HandleRx(uint32_t canId, uint32_t data[2], uint8_t dlc) override { recv(canId, data, dlc); }
+   void HandleClear() override { clear(); }
 
 private:
    bool (*recv)(uint32_t, uint32_t*, uint8_t);

--- a/include/canmap.h
+++ b/include/canmap.h
@@ -61,8 +61,8 @@ class CanMap: CanCallback
 
       CanMap(CanHardware* hw, bool loadFromFlash = true);
       CanHardware* GetHardware() { return canHardware; }
-      void HandleClear();
-      bool HandleRx(uint32_t canId, uint32_t data[2], uint8_t dlc);
+      void HandleClear() override;
+      void HandleRx(uint32_t canId, uint32_t data[2], uint8_t dlc) override;
       void Clear();
       void SendAll();
       int AddSend(Param::PARAM_NUM param, uint32_t canId, uint8_t offsetBits, int8_t length, float gain);

--- a/include/canobd2.h
+++ b/include/canobd2.h
@@ -26,8 +26,8 @@ class CanObd2: CanCallback
    public:
       /** Default constructor */
       CanObd2(CanHardware* hw);
-      void HandleClear();
-      bool HandleRx(uint32_t canId, uint32_t data[2], uint8_t dlc);
+      void HandleClear() override;
+      void HandleRx(uint32_t canId, uint32_t data[2], uint8_t dlc) override;
       void SetNodeId(uint8_t id);
 
    private:

--- a/include/cansdo.h
+++ b/include/cansdo.h
@@ -29,7 +29,7 @@ class CanSdo: CanCallback, public IPutChar
       /** Default constructor */
       CanSdo(CanHardware* hw, CanMap* cm = 0);
       void HandleClear();
-      bool HandleRx(uint32_t canId, uint32_t data[2], uint8_t dlc);
+      void HandleRx(uint32_t canId, uint32_t data[2], uint8_t dlc) override;
       void SDOWrite(uint8_t nodeId, uint16_t index, uint8_t subIndex, uint32_t data);
       void SDORead(uint8_t nodeId, uint16_t index, uint8_t subIndex);
       bool SDOReadReply(uint32_t& data);

--- a/src/canhardware.cpp
+++ b/src/canhardware.cpp
@@ -21,8 +21,8 @@
 class NullCallback: public CanCallback
 {
 public:
-   bool HandleRx(uint32_t, uint32_t*, uint8_t) { return false; }
-   void HandleClear() { }
+   void HandleRx(uint32_t, uint32_t*, uint8_t) override {}
+   void HandleClear() override { }
 };
 
 
@@ -96,7 +96,6 @@ void CanHardware::HandleRx(uint32_t canId, uint32_t data[2], uint8_t dlc)
 {
    for (int i = 0; i < nextCallbackIndex; i++)
    {
-      if (recvCallback[i]->HandleRx(canId, data, dlc))
-         break;
+      recvCallback[i]->HandleRx(canId, data, dlc);
    }
 }

--- a/src/canmap.cpp
+++ b/src/canmap.cpp
@@ -76,9 +76,9 @@ void CanMap::HandleClear()
    }
 }
 
-bool CanMap::HandleRx(uint32_t canId, uint32_t data[2], uint8_t)
+void CanMap::HandleRx(uint32_t canId, uint32_t data[2], uint8_t)
 {
-   if (isSaving) return false; //Only handle mapped messages when not currently saving to flash
+   if (isSaving) return; //Only handle mapped messages when not currently saving to flash
 
    CANIDMAP *recvMap = FindById(canRecvMap, canId);
 
@@ -162,10 +162,7 @@ bool CanMap::HandleRx(uint32_t canId, uint32_t data[2], uint8_t)
          else
             Param::SetFloat((Param::PARAM_NUM)curPos->mapParam, val);
       }
-      return true;
    }
-
-   return false;
 }
 
 /** \brief Clear all defined messages

--- a/src/canobd2.cpp
+++ b/src/canobd2.cpp
@@ -56,14 +56,12 @@ void CanObd2::HandleClear()
    canHardware->RegisterUserMessage(OBD2_PID_REQUEST + nodeId); // ECU specific address
 }
 
-bool CanObd2::HandleRx(uint32_t canId, uint32_t data[2], uint8_t)
+void CanObd2::HandleRx(uint32_t canId, uint32_t data[2], uint8_t)
 {
    if ((canId == OBD2_PID_REQUEST) || (canId == (OBD2_PID_REQUEST + nodeId))) //OBD2 request
    {
       ProcessOBD2(data);
-      return true;
    }
-   return false;
 }
 
 void CanObd2::SetNodeId(uint8_t id)

--- a/src/cansdo.cpp
+++ b/src/cansdo.cpp
@@ -87,20 +87,17 @@ void CanSdo::HandleClear()
       canHardware->RegisterUserMessage(SDO_REP_ID_BASE + remoteNodeId);
 }
 
-bool CanSdo::HandleRx(uint32_t canId, uint32_t data[2], uint8_t)
+void CanSdo::HandleRx(uint32_t canId, uint32_t data[2], uint8_t)
 {
    if (canId == (SDO_REQ_ID_BASE + nodeId)) //SDO request
    {
       ProcessSDO(data);
-      return true;
    }
    else if (canId == (SDO_REP_ID_BASE + remoteNodeId))
    {
       sdoReplyValid = (data[0] & 0xFF) != SDO_ABORT;
       sdoReplyData = data[1];
-      return true;
    }
-   return false;
 }
 
 void CanSdo::SDOWrite(uint8_t nodeId, uint16_t index, uint8_t subIndex, uint32_t data)


### PR DESCRIPTION
CanCallback::HandleRx no longer returns a bool indicating whether the message has been handled. The message is passed to all handlers allowing user defined handlers to see messages that have been handled by CanMap.

Tests:
 - Build with stm32-sine for SINE and FOC configurations
 - Basic verification of CAN SDO and CAN RX map functionality