### PR TITLE
Add BUS based IO (busio) support

### DIFF
--- a/src/digio.cpp
+++ b/src/digio.cpp
@@ -25,6 +25,12 @@
 
 #undef DIG_IO_ENTRY
 #define DIG_IO_ENTRY(name, port, pin, mode) DigIo DigIo::name;
+
+#ifdef BUSIO_ENABLED    
+#undef  BUS_IO_ENTRY
+#define BUS_IO_ENTRY(name, busType, channel, mode) BusIo DigIo::name;
+#endif
+
 DIG_IO_LIST
 
 void DigIo::Configure(uint32_t port, uint16_t pin, PinMode::PinMode pinMode)


### PR DESCRIPTION
This is a small addition to the existing pin macros that allows an application using libopeninv to drive bus based I/O,  which may be on SPI,LIN,CAN,I2C etc., using the existing digio API eg

```
DigIo::lin_nslp.Toggle();
```
In order for this to be enabled,  first create a busio.h/cpp file in your libopeninv project and include the drivers for the BUS device of interest.

A minimal example of a busio.h/cpp implementation that exposes the MCP2515 GPIO to digio is available [here](https://github.com/jetpax/HeadlessZombie)

Then, adding pins is done in digio_prj.h in the usual way, eg
```
   DIG_IO_ENTRY(gp_12Vin,  GPIOE, GPIO7,  PinMode::INPUT_FLT)   \
    BUS_IO_ENTRY(can2_term, BusType::MCP2515, 0x00, BusPinMode::OUTPUT) \
```

(Note that the bus type relates to the physical device that provides the interface; its just an enum that allows the code to dispatch pin commands to the right handler.)

Adding support for other devices or busses is by expanding the relevant enums

```enum class BusType : uint8_t
{
    MCP2515,
    TIC12400,
    DRV8912,
    UJA1023
};

// Bus IO pin modes 
enum class BusPinMode : uint8_t
{
    HI_Z,
    OUTPUT
};// pin modes 
```

and adding the corresponding Configure() and set()/get() handlers.

The implementation has no effect on existing I/O, but obviously this is not as fast as direct GPIO as it is over a bus.
Nonetheless, on SPI an MCP2515 output pin can be toggled in ~10us.

