### PR TITLE
Fix SDO response when removing can map entries

### DIFF
--- a/src/cansdo.cpp
+++ b/src/cansdo.cpp
@@ -274,6 +274,7 @@ void CanSdo::ReadOrDeleteCanMap(SdoFrame* sdo)
    else if (sdo->cmd == SDO_WRITE && canPos != 0 && sdo->data == 0)
    {
       canMap->Remove(rx, sdo->index & 0x3f, itemIdx);
+      sdo->cmd = SDO_WRITE_REPLY;
    }
    else
    {


### PR DESCRIPTION
Highlighted by an update to the canopen python library used by the openinverter_can_tool which more thoroughly handles poorly formed SDO responses.

Tests:
 - Create and remove can map entries with "oic can add" and "oic can remove".
 - Verify CAN frames now decode correctly in Wireshark as:
  CANopen	Default-SDO (rx): Initiate download request
  CANopen	Default-SDO (tx): Initiate download response