### PR TITLE
Add UART4 and split init support to LinBus

### DIFF
--- a/include/linbus.h
+++ b/include/linbus.h
@@ -19,12 +19,15 @@
 #ifndef LINBUS_H
 #define LINBUS_H
 
+#include <stdint.h>
 
 class LinBus
 {
    public:
       /** Default constructor */
+      LinBus();
       LinBus(uint32_t usart, int baudrate);
+      void Init(uint32_t usart, int baudrate);
       void Request(uint8_t id, uint8_t* data, uint8_t len);
       bool HasReceived(uint8_t pid, uint8_t requiredLen);
       uint8_t* GetReceivedBytes() { return &recvBuffer[payloadIndex]; }
@@ -35,10 +38,12 @@ class LinBus
       struct HwInfo
       {
          uint32_t usart;
+         uint32_t dma;
          uint8_t dmatx;
          uint8_t dmarx;
          uint32_t port;
-         uint16_t pin;
+         uint16_t pintx;
+         uint16_t pinrx;
       };
 
       static uint8_t Checksum(uint8_t pid, uint8_t* data, int len);
@@ -47,7 +52,6 @@ class LinBus
       static const HwInfo hwInfo[];
       static const int payloadIndex = 3;
       static const int pidIndex = 2;
-      uint32_t usart;
       const HwInfo* hw;
       uint8_t sendBuffer[11];
       uint8_t recvBuffer[12];


### PR DESCRIPTION
Allowing a LIN bus connected to UART4 on high-density parts like STM32F103VCT6 needs support for DMA channel 2 in the HwInfo struct.

Initialise the GPIO for RX which is necessary to get UART4 LIN connections to work and seems good practice for all pins.

Remove duplicate field referencing the USART base
register.

Allow split initialisation where the memory is setup but no IO happens until a new Init() method is called. This allows integration into applications where the memory location is shared between multiple hardware variants. The existing constructor remains so current users are unaffected.

Tests:
 - Build into Stm32-vcu and test with simulated VWCoolant LIN heater. Verify status values are returned and command sent to the device.
 - Build into stm32-sine with M3DU V1 board and simulated Tesla M3 oil pump. Verify command and status responses are delivered as expected.