### PR TITLE
Make it possible to tell Term that you can't handle fastuart

### DIFF
--- a/include/terminal.h
+++ b/include/terminal.h
@@ -32,7 +32,7 @@ typedef struct
 class Terminal: public IPutChar
 {
 public:
-   Terminal(uint32_t usart, const TERM_CMD* commands, bool remap = false, bool echo = true);
+   Terminal(uint32_t usart, const TERM_CMD* commands, bool remap = false, bool echo = true, bool enablefastuart = true);
    void SetNodeId(uint8_t id);
    void Run();
    void PutChar(char c);
@@ -82,6 +82,7 @@ private:
    char inBuf[bufSize];
    char outBuf[2][bufSize]; //double buffering
    char args[bufSize];
+   bool enablefastuart;
 };
 
 #endif // TERMINAL_H

--- a/src/terminal.cpp
+++ b/src/terminal.cpp
@@ -41,7 +41,7 @@ const Terminal::HwInfo Terminal::hwInfo[] =
 
 Terminal* Terminal::defaultTerminal;
 
-Terminal::Terminal(uint32_t usart, const TERM_CMD* commands, bool remap, bool echo)
+Terminal::Terminal(uint32_t usart, const TERM_CMD* commands, bool remap, bool echo, bool enablefastuart)
 :  usart(usart),
    remap(remap),
    termCmds(commands),
@@ -53,7 +53,8 @@ Terminal::Terminal(uint32_t usart, const TERM_CMD* commands, bool remap, bool ec
    curBuf(0),
    curIdx(0),
    firstSend(true),
-   echo(echo)
+   echo(echo),
+   enablefastuart(enablefastuart)
 {
    //Search info entry
    hw = hwInfo;
@@ -146,8 +147,12 @@ void Terminal::Run()
             }
             else if (my_strcmp(inBuf, "fastuart") == 0)
             {
-               FastUart(args);
-               currentIdx = 0;
+              if (enablefastuart) {
+                FastUart(args);
+              } else {
+                Send("fastuart not available\r\n");
+              }
+              currentIdx = 0;
             }
             else if (my_strcmp(inBuf, "echo") == 0)
             {


### PR DESCRIPTION
Add the ability have the Terminal reject fastuart requests.

This is based on the current version used by stm32-vcu:Vehicle_Testing so I can use it there and not have to pull in these other changes to the master branch.