### PR TITLE
Allow listing of errors via CANopen SDO

### DIFF
--- a/include/errormessage.h
+++ b/include/errormessage.h
@@ -48,6 +48,8 @@ class ErrorMessage
       static void PrintAllErrors();
       static void PrintNewErrors();
       static ERROR_MESSAGE_NUM GetLastError();
+      static ERROR_MESSAGE_NUM GetErrorNum(uint8_t index);
+      static uint32_t GetErrorTime(uint8_t index);
    protected:
    private:
       static void PrintError(uint32_t time, ERROR_MESSAGE_NUM err);

--- a/src/cansdo.cpp
+++ b/src/cansdo.cpp
@@ -18,6 +18,7 @@
  */
 #include "cansdo.h"
 #include "my_math.h"
+#include "errormessage.h"
 
 #define SDO_REQ_ID_BASE       0x600U
 #define SDO_REP_ID_BASE       0x580U
@@ -28,6 +29,9 @@
 #define SDO_INDEX_MAP_RX      0x3001
 #define SDO_INDEX_MAP_RD      0x3100
 #define SDO_INDEX_STRINGS     0x5001
+#define SDO_INDEX_ERROR_NUM   0x5002
+#define SDO_INDEX_ERROR_TIME  0x5003
+
 
 #define PRINT_BUF_ENQUEUE(c)  printBuffer[(printByteIn++) & (sizeof(printBuffer) - 1)] = c
 #define PRINT_BUF_DEQUEUE()   printBuffer[(printByteOut++) & (sizeof(printBuffer) - 1)]
@@ -195,6 +199,32 @@ void CanSdo::ProcessSDO(uint32_t data[2])
    else if (0 != canMap && (sdo->index & 0xFF00) == SDO_INDEX_MAP_RD)
    {
       ReadOrDeleteCanMap(sdo);
+   }
+   else if (sdo->index == SDO_INDEX_ERROR_NUM)
+   {
+      if (sdo->cmd == SDO_READ)
+      {
+         sdo->data = ErrorMessage::GetErrorNum(sdo->subIndex);
+         sdo->cmd = SDO_READ_REPLY;
+      }
+      else
+      {
+         sdo->cmd = SDO_ABORT;
+         sdo->data = SDO_ERR_INVIDX;
+      }
+   }
+   else if (sdo->index == SDO_INDEX_ERROR_TIME)
+   {
+      if (sdo->cmd == SDO_READ)
+      {
+         sdo->data = ErrorMessage::GetErrorTime(sdo->subIndex);
+         sdo->cmd = SDO_READ_REPLY;
+      }
+      else
+      {
+         sdo->cmd = SDO_ABORT;
+         sdo->data = SDO_ERR_INVIDX;
+      }
    }
    else
    {

--- a/src/errormessage.cpp
+++ b/src/errormessage.cpp
@@ -106,6 +106,27 @@ ERROR_MESSAGE_NUM ErrorMessage::GetLastError()
    return lastError;
 }
 
+ERROR_MESSAGE_NUM ErrorMessage::GetErrorNum(uint8_t index)
+{
+   if (index < ERROR_BUF_SIZE)
+   {
+      if (errorBuffer[index].time > 0)
+         return errorBuffer[index].msg;
+   }
+
+   return ERROR_NONE;
+}
+
+uint32_t ErrorMessage::GetErrorTime(uint8_t index)
+{
+   if (index < ERROR_BUF_SIZE)
+   {
+      return errorBuffer[index].time;
+   }
+
+   return 0;
+}
+
 /** Print all errors currently in error memory */
 void ErrorMessage::PrintAllErrors()
 {


### PR DESCRIPTION
This exports the list of errors and time at which they occurred as two CANopen SDO arrays. The sub-
index is used as an index into the list of errors. Any invalid indices return zero.

Clients can use the "lasterr" parameter database
spot-value which is present in all libopeninv projects to map the error number to a string.

Tests:
 - Verify with updated OpenInverter CAN Tool that errors can be listed.
 - Initiate an new error after a period of time and ensure the list tallies with the elapsed wall-clock time.
 - Check CANopen SDO decodes as expected in Wireshark