### PR TITLE
Fix CANopen SDO index for retrieving errors

### DIFF
--- a/src/cansdo.cpp
+++ b/src/cansdo.cpp
@@ -29,8 +29,8 @@
 #define SDO_INDEX_MAP_RX      0x3001
 #define SDO_INDEX_MAP_RD      0x3100
 #define SDO_INDEX_STRINGS     0x5001
-#define SDO_INDEX_ERROR_NUM   0x5002
-#define SDO_INDEX_ERROR_TIME  0x5003
+#define SDO_INDEX_ERROR_NUM   0x5003
+#define SDO_INDEX_ERROR_TIME  0x5004
 
 
 #define PRINT_BUF_ENQUEUE(c)  printBuffer[(printByteIn++) & (sizeof(printBuffer) - 1)] = c


### PR DESCRIPTION
Commit 087010a4 broke user space
commands (load, save, default, start, stop) by
using the SDO index 0x5002. Fix this by
moving the two SDO indices to 0x5003 and
0x5004.

Tests:
 - Retest error posting and display via CAN and an updated OpenInverter CAN Tool
 - Start and stop the stm32-sine inveter via CAN