### PR TITLE
Cleanup CanMap, CanSdo and Stm32Can declarations

### DIFF
--- a/include/canmap.h
+++ b/include/canmap.h
@@ -59,7 +59,7 @@ class CanMap: CanCallback
          uint8_t next;
       };
 
-      CanMap(CanHardware* hw, bool loadFromFlash = true);
+      explicit CanMap(CanHardware* hw, bool loadFromFlash = true);
       CanHardware* GetHardware() { return canHardware; }
       void HandleClear() override;
       void HandleRx(uint32_t canId, uint32_t data[2], uint8_t dlc) override;
@@ -95,7 +95,6 @@ class CanMap: CanCallback
       CANIDMAP canSendMap[MAX_MESSAGES];
       CANIDMAP canRecvMap[MAX_MESSAGES];
       CANPOS canPosMap[MAX_ITEMS + 1]; //Last item is a "tail"
-      uint32_t lastRxTimestamp;
 
       void ClearMap(CANIDMAP *canMap);
       int Add(CANIDMAP *canMap, Param::PARAM_NUM param, uint32_t canId, uint8_t offsetBits, int8_t length, float gain, int8_t offset);

--- a/include/cansdo.h
+++ b/include/cansdo.h
@@ -52,9 +52,9 @@ class CanSdo: CanCallback, public IPutChar
       } __attribute__((packed));
 
       /** Default constructor */
-      CanSdo(CanHardware* hw, CanMap* cm = 0);
+      explicit CanSdo(CanHardware* hw, CanMap* cm = 0);
       CanHardware* GetHardware() { return canHardware; }
-      void HandleClear();
+      void HandleClear() override;
       void HandleRx(uint32_t canId, uint32_t data[2], uint8_t dlc) override;
       void SDOWrite(uint8_t nodeId, uint16_t index, uint8_t subIndex, uint32_t data);
       void SDORead(uint8_t nodeId, uint16_t index, uint8_t subIndex);
@@ -64,7 +64,7 @@ class CanSdo: CanCallback, public IPutChar
       int GetPrintRequest() { return printRequest; }
       SdoFrame* GetPendingUserspaceSdo() { return pendingUserSpaceSdo ? &pendingUserSpaceSdoFrame : 0; }
       void SendSdoReply(SdoFrame* sdoFrame);
-      void PutChar(char c);
+      void PutChar(char c) override;
       void TriggerTimeout(int callingFrequency);
 
    private:

--- a/include/stm32_can.h
+++ b/include/stm32_can.h
@@ -51,7 +51,6 @@ private:
    void SetFilterBank(int& idIndex, int& filterId, uint16_t* idList);
    void SetFilterBankMask(int& idIndex, int& filterId, uint16_t* idMaskList);
    void SetFilterBank29(int& idIndex, int& filterId, uint32_t* idList);
-   uint32_t GetFlashAddress();
 
    static Stm32Can* interfaces[];
 };


### PR DESCRIPTION
Make single parameter constructors explicit.
Use "override" on all overridden virtual methods.
Remove unused timestamp from CanMap.
Remove unused GetFlashAddress from Stm32Can.

Tests:
 - Build as part of VCU project