### PR TITLE
Allow Extended flag with low IDs

### DIFF
--- a/include/canhardware.h
+++ b/include/canhardware.h
@@ -53,7 +53,7 @@ class CanHardware
    public:
       enum baudrates
       {
-         Baud125, Baud250, Baud500, Baud800, Baud1000, BaudLast
+         Baud125, Baud250, Baud500, Baud800, Baud1000, Baud33, BaudLast
       };
 
       CanHardware();

--- a/include/canhardware.h
+++ b/include/canhardware.h
@@ -53,14 +53,16 @@ class CanHardware
    public:
       enum baudrates
       {
-         Baud125, Baud250, Baud500, Baud800, Baud1000, Baud33, BaudLast
+         Baud125, Baud250, Baud500, Baud800, Baud1000, BaudLast
       };
 
       CanHardware();
       virtual void SetBaudrate(enum baudrates baudrate) = 0;
-      void Send(uint32_t canId, uint32_t data[2]) { Send(canId, data, 8); }
-      void Send(uint32_t canId, uint8_t data[8], uint8_t len) { Send(canId, (uint32_t*)data, len); }
-      virtual void Send(uint32_t canId, uint32_t data[2], uint8_t len) = 0;
+      void Send(uint32_t canId, uint32_t data[2]) { Send(canId, data, 8, false); }
+      void Send(uint32_t canId, uint8_t data[8], uint8_t len) { Send(canId, (uint32_t*)data, len, false); }
+      void Send(uint32_t canId, uint8_t data[8], uint8_t len, bool ext) { Send(canId, (uint32_t*)data, len, ext); }
+      void Send(uint32_t canId, uint32_t data[2], uint8_t len) { Send(canId, (uint32_t*)data, len, false); }
+      virtual void Send(uint32_t canId, uint32_t data[2], uint8_t len, bool ext) = 0;
       void HandleRx(uint32_t canId, uint32_t data[2], uint8_t dlc);
       bool AddCallback(CanCallback* cb);
       bool RegisterUserMessage(uint32_t canId, uint32_t mask = 0);

--- a/include/stm32_can.h
+++ b/include/stm32_can.h
@@ -30,7 +30,7 @@ class Stm32Can: public CanHardware
 public:
    Stm32Can(uint32_t baseAddr, enum baudrates baudrate, bool remap = false);
    void SetBaudrate(enum baudrates baudrate);
-   void Send(uint32_t canId, uint32_t data[2], uint8_t len);
+   void Send(uint32_t canId, uint32_t data[2], uint8_t len, bool ext);
    void HandleTx();
    void HandleMessage(int fifo);
    static Stm32Can* GetInterface(int index);

--- a/src/stm32_can.cpp
+++ b/src/stm32_can.cpp
@@ -77,6 +77,7 @@ static const CANSPEED canSpeed[CanHardware::BaudLast] =
    { CAN_BTR_TS1_13TQ, CAN_BTR_TS2_2TQ, 2 }, //500kbps at 16 MHz
    { CAN_BTR_TS1_8TQ,  CAN_BTR_TS2_1TQ, 2 }, //800kbps at 16 MHz
    { CAN_BTR_TS1_13TQ, CAN_BTR_TS2_2TQ, 1 }, //1000kbps at 36 MHz
+   { CAN_BTR_TS1_11TQ, CAN_BTR_TS2_4TQ, 30 }, //33.3kbps at 16 MHz
 };
 #elif CAN_PERIPH_SPEED == 32
 {
@@ -85,6 +86,7 @@ static const CANSPEED canSpeed[CanHardware::BaudLast] =
    { CAN_BTR_TS1_13TQ, CAN_BTR_TS2_2TQ, 4 }, //500kbps at 32 MHz
    { CAN_BTR_TS1_8TQ,  CAN_BTR_TS2_1TQ, 4 }, //800kbps at 32 MHz
    { CAN_BTR_TS1_13TQ, CAN_BTR_TS2_2TQ, 2 }, //1000kbps at 32 MHz
+   { CAN_BTR_TS1_11TQ, CAN_BTR_TS2_4TQ, 60 }, //33.3kbps at 32 MHz
 };
 #elif CAN_PERIPH_SPEED == 36
 {
@@ -93,6 +95,7 @@ static const CANSPEED canSpeed[CanHardware::BaudLast] =
    { CAN_BTR_TS1_4TQ, CAN_BTR_TS2_3TQ, 9 }, //500kbps at 36 MHz
    { CAN_BTR_TS1_5TQ, CAN_BTR_TS2_3TQ, 5 }, //800kbps at 36 MHz
    { CAN_BTR_TS1_6TQ, CAN_BTR_TS2_5TQ, 3 }, //1000kbps at 36 MHz
+   { CAN_BTR_TS1_8TQ, CAN_BTR_TS2_3TQ, 90}, //33.3kbps at 36 MHz
 };
 #else
 #error Unhandled CAN peripheral speed, please define prescalers

--- a/src/stm32_can.cpp
+++ b/src/stm32_can.cpp
@@ -77,7 +77,6 @@ static const CANSPEED canSpeed[CanHardware::BaudLast] =
    { CAN_BTR_TS1_13TQ, CAN_BTR_TS2_2TQ, 2 }, //500kbps at 16 MHz
    { CAN_BTR_TS1_8TQ,  CAN_BTR_TS2_1TQ, 2 }, //800kbps at 16 MHz
    { CAN_BTR_TS1_13TQ, CAN_BTR_TS2_2TQ, 1 }, //1000kbps at 36 MHz
-   { CAN_BTR_TS1_11TQ, CAN_BTR_TS2_4TQ, 30 }, //33.3kbps at 16 MHz
 };
 #elif CAN_PERIPH_SPEED == 32
 {
@@ -86,7 +85,6 @@ static const CANSPEED canSpeed[CanHardware::BaudLast] =
    { CAN_BTR_TS1_13TQ, CAN_BTR_TS2_2TQ, 4 }, //500kbps at 32 MHz
    { CAN_BTR_TS1_8TQ,  CAN_BTR_TS2_1TQ, 4 }, //800kbps at 32 MHz
    { CAN_BTR_TS1_13TQ, CAN_BTR_TS2_2TQ, 2 }, //1000kbps at 32 MHz
-   { CAN_BTR_TS1_11TQ, CAN_BTR_TS2_4TQ, 60 }, //33.3kbps at 32 MHz
 };
 #elif CAN_PERIPH_SPEED == 36
 {
@@ -95,7 +93,6 @@ static const CANSPEED canSpeed[CanHardware::BaudLast] =
    { CAN_BTR_TS1_4TQ, CAN_BTR_TS2_3TQ, 9 }, //500kbps at 36 MHz
    { CAN_BTR_TS1_5TQ, CAN_BTR_TS2_3TQ, 5 }, //800kbps at 36 MHz
    { CAN_BTR_TS1_6TQ, CAN_BTR_TS2_5TQ, 3 }, //1000kbps at 36 MHz
-   { CAN_BTR_TS1_8TQ, CAN_BTR_TS2_3TQ, 90}, //33.3kbps at 36 MHz
 };
 #else
 #error Unhandled CAN peripheral speed, please define prescalers
@@ -222,21 +219,38 @@ void Stm32Can::SetBaudrate(enum baudrates baudrate)
  * \return void
  *
  */
-void Stm32Can::Send(uint32_t canId, uint32_t data[2], uint8_t len)
+void Stm32Can::Send(uint32_t canId, uint32_t data[2], uint8_t len, bool ext)
 {
    DISABLE_CAN_USER_INTERRUPTS();
 
    can_disable_irq(canDev, CAN_IER_TMEIE);
 
-   if (can_transmit(canDev, canId, canId > 0x7FF, false, len, (uint8_t*)data) < 0 && sendCnt < SENDBUFFER_LEN)
+   if(ext)
    {
-      /* enqueue in send buffer if all TX mailboxes are full */
-      sendBuffer[sendCnt].id = canId;
-      sendBuffer[sendCnt].len = len;
-      sendBuffer[sendCnt].data[0] = data[0];
-      sendBuffer[sendCnt].data[1] = data[1];
-      sendCnt++;
+     if (can_transmit(canDev, canId, ext, false, len, (uint8_t*)data) < 0 && sendCnt < SENDBUFFER_LEN)
+     {
+        /* enqueue in send buffer if all TX mailboxes are full */
+        sendBuffer[sendCnt].id = canId;
+        sendBuffer[sendCnt].len = len;
+        sendBuffer[sendCnt].data[0] = data[0];
+        sendBuffer[sendCnt].data[1] = data[1];
+        sendCnt++;
+     }
    }
+   else
+   {
+     if (can_transmit(canDev, canId, canId > 0x7FF, false, len, (uint8_t*)data) < 0 && sendCnt < SENDBUFFER_LEN)
+     {
+        /* enqueue in send buffer if all TX mailboxes are full */
+        sendBuffer[sendCnt].id = canId;
+        sendBuffer[sendCnt].len = len;
+        sendBuffer[sendCnt].data[0] = data[0];
+        sendBuffer[sendCnt].data[1] = data[1];
+        sendCnt++;
+     }
+
+   }
+
 
    if (sendCnt > 0)
    {


### PR DESCRIPTION
Introduce the allowing of setting extended flag is ID is under 0x7FF